### PR TITLE
[feat] Add performance and separation quality benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ Session.vim
 *.onnx
 *.ort
 *.config
+/cppscripts/build

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "cppscripts/dependencies/eigen"]
+	path = cppscripts/dependencies/eigen
+	url = https://gitlab.com/libeigen/eigen.git
+[submodule "cppscripts/dependencies/libnyquist"]
+	path = cppscripts/dependencies/libnyquist
+	url = https://github.com/ddiakopoulos/libnyquist.git

--- a/benchmark/benchmark-cpp-onnx.py
+++ b/benchmark/benchmark-cpp-onnx.py
@@ -1,0 +1,65 @@
+"""
+C++ ONNX-based Demucs benchmarking script.
+
+This script uses C++ ONNX CLI tool for inference and imports common functionality
+from benchmark_common to avoid code duplication.
+"""
+
+import argparse
+import subprocess
+from pathlib import Path
+
+from benchmark_common import run_benchmark
+
+DEFAULT_CLI_PATH = '../cppscripts/build/build-cli/demucs'
+DEFAULT_MODEL_PATH = '../onnx-models/htdemucs.ort'
+
+
+def separate_cpp_onnx(mixture_path, out_dir, cli_path, model_path):
+    """Separate audio using C++ ONNX CLI tool."""
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    
+    cmd = [str(cli_path), str(model_path), str(mixture_path), str(out_dir)]
+    subprocess.run(cmd, check=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Benchmark Demucs separation using C++ ONNX CLI')
+    parser.add_argument('--musdb-root', type=Path, help='Path to MusDB root', required=True)
+    parser.add_argument('--output-root', type=Path, default=None, help='Where to store separated outputs (default: inside musdb-root)')
+    parser.add_argument('--output-dir', type=str, default='test-separated-cpp', help='Output directory name (default: test-separated-cpp)')
+    parser.add_argument('--json-out', type=str, default='benchmark_results_cpp.json', help='Output JSON file for benchmarks')
+    parser.add_argument('--cli-path', type=str, default=DEFAULT_CLI_PATH, help='Path to the C++ ONNX CLI executable')
+    parser.add_argument('--model-path', type=str, default=DEFAULT_MODEL_PATH, help='Path to the ONNX model file')
+    parser.add_argument('--force-reseparate', action='store_true', help='Force re-separation even if files already exist')
+    args = parser.parse_args()
+    
+    # Setup paths
+    musdb_root = Path(args.musdb_root)
+    output_root = Path(args.output_root) if args.output_root else musdb_root
+    out_dir = output_root / args.output_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+    
+    cli_path = Path(args.cli_path)
+    model_path = Path(args.model_path)
+    
+    print(f'Using CLI: {cli_path}')
+    print(f'Using model: {model_path}')
+
+    # Run benchmark using common flow
+    run_benchmark(
+        musdb_root=musdb_root,
+        out_dir=out_dir,
+        force_reseparate=args.force_reseparate,
+        json_out=args.json_out,
+        separate_func=separate_cpp_onnx,
+        model_identifier=str(model_path),
+        # Arguments passed to separate_cpp_onnx
+        cli_path=cli_path,
+        model_path=model_path
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/benchmark/benchmark-pytorch.py
+++ b/benchmark/benchmark-pytorch.py
@@ -1,0 +1,82 @@
+"""
+PyTorch-based Demucs benchmarking script.
+
+This script uses PyTorch for inference and imports common functionality
+from benchmark_common to avoid code duplication.
+"""
+
+import argparse
+from pathlib import Path
+
+import torchaudio
+from demucs.apply import apply_model
+from demucs.pretrained import get_model
+
+from benchmark_common import run_benchmark, STEM_MAP, STEM_NAMES
+
+DEFAULT_MODEL = 'htdemucs'
+
+
+def separate_pytorch(mixture_path, out_dir, model_name):
+    """Separate audio using PyTorch Demucs model."""
+    # Load model
+    model = get_model(model_name)
+    
+    # Load and preprocess audio
+    audio, rate = torchaudio.load(str(mixture_path))
+    if rate != 44100:
+        audio = torchaudio.functional.resample(audio, rate, 44100)
+    
+    # Normalize
+    ref = audio.mean(0)
+    audio = (audio - ref.mean()) / ref.std()
+    
+    # Apply model
+    sources = apply_model(model, audio[None])[0]
+    
+    # Denormalize
+    sources = sources * ref.std() + ref.mean()
+    
+    # Save stems
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for target_idx in range(len(STEM_NAMES)):
+        target_name = STEM_MAP[target_idx]
+        out_audio = sources[target_idx].detach().cpu()
+        out_path = out_dir / f'target_{target_idx}_{target_name}.wav'
+        torchaudio.save(str(out_path), out_audio, sample_rate=44100)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='PyTorch Demucs Benchmarking Script')
+    parser.add_argument('--musdb-root', type=Path, help='Path to MusDB root', required=True)
+    parser.add_argument('--output-root', type=Path, default=None, help='Where to store separated outputs (default: inside musdb-root)')
+    parser.add_argument('--output-dir', type=str, default='test-separated-pytorch', help='Output directory name (default: test-separated-pytorch)')
+    parser.add_argument('--json-out', type=str, default='benchmark_results_pytorch.json', help='Output JSON file for benchmarks')
+    parser.add_argument('--force-reseparate', action='store_true', help='Force re-separation even if files already exist')
+    args = parser.parse_args()
+
+    # Setup paths
+    musdb_root = Path(args.musdb_root)
+    output_root = Path(args.output_root) if args.output_root else musdb_root
+    out_dir = output_root / args.output_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+    
+    model_name = DEFAULT_MODEL
+    print(f'Using model: {model_name}')
+
+    # Run benchmark using common flow
+    run_benchmark(
+        musdb_root=musdb_root,
+        out_dir=out_dir,
+        force_reseparate=args.force_reseparate,
+        json_out=args.json_out,
+        separate_func=separate_pytorch,
+        model_identifier=model_name,
+        # Arguments passed to separate_pytorch
+        model_name=model_name
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/benchmark/benchmark_common.py
+++ b/benchmark/benchmark_common.py
@@ -1,0 +1,256 @@
+"""
+Common functionality for Demucs benchmarking scripts.
+
+This module contains shared code between benchmark-pytorch.py and benchmark-cpp-onnx.py
+to eliminate duplication and ensure consistency across different backends.
+"""
+
+import time
+import json
+from pathlib import Path
+from typing import Dict, List, Callable
+
+import numpy as np
+import torch
+import torchaudio
+from torchmetrics.audio import ScaleInvariantSignalDistortionRatio
+
+STEM_NAMES = ['drums', 'bass', 'other', 'vocals']
+STEM_MAP = {i: name for i, name in enumerate(STEM_NAMES)}
+GT_STEM_FILES = [f'{name}.wav' for name in STEM_NAMES]
+SEP_STEM_FILES = [f'target_{i}_{name}.wav' for i, name in enumerate(STEM_NAMES)]
+
+
+def find_mixture_wavs(root):
+    """Find all mixture.wav files in the directory tree."""
+    root = Path(root)
+    return list(root.rglob('mixture.wav'))
+
+
+def check_track_separated(sep_dir):
+    """Check if all expected stem files exist for a track."""
+    if not sep_dir.exists():
+        return False
+    
+    for sep_stem in SEP_STEM_FILES:
+        sep_path = sep_dir / sep_stem
+        if not sep_path.exists():
+            return False
+    
+    return True
+
+
+def compute_sisdr(ref, est, metric):
+    """Compute SI-SDR between reference and estimated audio tensors."""
+    # Ensure tensors are 2D: [channels, samples]
+    if ref.ndim == 1:
+        ref = ref.unsqueeze(0)
+    if est.ndim == 1:
+        est = est.unsqueeze(0)
+    
+    # Align lengths
+    min_len = min(ref.shape[-1], est.shape[-1])
+    ref = ref[..., :min_len]
+    est = est[..., :min_len]
+    
+    with torch.no_grad():
+        score = metric(est, ref)
+    return float(score)
+
+
+def evaluate_sisdr(musdb_test: Path, out_dir: Path, per_track_stats: List[Dict]) -> tuple:
+    """
+    Evaluate SI-SDR scores for all separated tracks.
+    
+    Returns:
+        tuple: (tm_scores dict, per_track_sisdr list)
+    """
+    print("\nEvaluating SI-SDR...")
+    sisdr_metric = ScaleInvariantSignalDistortionRatio()
+    tm_scores = {stem: [] for stem in STEM_NAMES}
+    per_track_sisdr = []
+    
+    for track_stat in per_track_stats:
+        rel_dir = Path(track_stat['track'])
+        gt_dir = musdb_test / rel_dir
+        sep_dir = out_dir / rel_dir
+        track_sisdr = {}
+        
+        for gt_stem, sep_stem, stem_name in zip(GT_STEM_FILES, SEP_STEM_FILES, STEM_NAMES):
+            gt_path = gt_dir / gt_stem
+            sep_path = sep_dir / sep_stem
+            
+            if not gt_path.exists() or not sep_path.exists():
+                continue
+            
+            # Load audio using torchaudio
+            gt_audio, sr_gt = torchaudio.load(str(gt_path))
+            sep_audio, sr_sep = torchaudio.load(str(sep_path))
+            
+            if sr_gt != sr_sep:
+                print(f'  Sample rate mismatch: {gt_stem} (gt: {sr_gt}, sep: {sr_sep})')
+                continue
+            
+            sisdr = compute_sisdr(gt_audio, sep_audio, sisdr_metric)
+            tm_scores[stem_name].append(sisdr)
+            track_sisdr[stem_name] = sisdr
+        
+        per_track_sisdr.append({'track': str(rel_dir), 'sisdr': track_sisdr})
+    
+    return tm_scores, per_track_sisdr
+
+
+def print_timing_summary(total_start: float, total_end: float, total_proc_sec: float, 
+                        total_audio_sec: float, separated_count: int, skipped_count: int, 
+                        total_tracks: int):
+    """Print timing summary statistics."""
+    print(f"\n{'='*60}")
+    print("Separation Summary:")
+    print(f"  Total tracks: {total_tracks}")
+    print(f"  Separated: {separated_count}")
+    print(f"  Skipped (already existed): {skipped_count}")
+    print(f"  Wall time: {total_end - total_start:.2f} seconds")
+    print(f"  Processing time: {total_proc_sec:.2f} seconds")
+    print(f"  Total audio: {total_audio_sec/60:.2f} minutes")
+    if total_proc_sec > 0 and total_audio_sec > 0:
+        avg_time_per_min = total_proc_sec / (total_audio_sec/60)
+        print(f"  Average time per minute (separated tracks): {avg_time_per_min:.2f} seconds")
+    print(f"{'='*60}")
+
+
+def create_summary(model_identifier: str, total_tracks: int, total_proc_sec: float, 
+                  total_wall_time_sec: float, total_audio_sec: float, tm_scores: Dict) -> Dict:
+    """Create summary statistics dictionary."""
+    return {
+        'model_identifier': model_identifier,
+        'total_tracks': total_tracks,
+        'total_proc_sec': total_proc_sec,
+        'total_wall_time_sec': total_wall_time_sec,
+        'total_audio_sec': total_audio_sec,
+        'avg_time_per_min': total_proc_sec / (total_audio_sec/60) if total_audio_sec > 0 else None,
+        'sisdr_mean_per_stem': {stem: float(np.mean(scores)) if scores else None for stem, scores in tm_scores.items()},
+        'overall_sisdr_mean': float(np.mean([s for scores in tm_scores.values() for s in scores])) if any(tm_scores.values()) else None
+    }
+
+
+def save_results(results: Dict, json_path: Path):
+    """Save benchmark results to JSON file and print summary."""
+    with open(json_path, 'w') as f:
+        json.dump(results, f, indent=2)
+    
+    summary = results['summary']
+    print(f'\nBenchmark results written to {json_path}')
+    print(f"Overall SI-SDR: {summary['overall_sisdr_mean']:.2f} dB" if summary['overall_sisdr_mean'] else "Overall SI-SDR: N/A")
+
+
+def run_benchmark(musdb_root: Path, out_dir: Path, force_reseparate: bool, 
+                 json_out: str, separate_func: Callable, model_identifier: str, 
+                 **separate_kwargs) -> Dict:
+    """
+    Main benchmarking flow that works with any separation backend.
+    
+    Args:
+        musdb_root: Path to MusDB dataset root
+        out_dir: Output directory for separated tracks
+        force_reseparate: Whether to force re-separation
+        json_out: JSON output filename
+        separate_func: Function to call for separation (backend-specific)
+        model_identifier: String identifier for the model/backend used
+        **separate_kwargs: Additional arguments to pass to separate_func
+    
+    Returns:
+        Dictionary with benchmark results
+    """
+    # Setup paths
+    musdb_test = musdb_root / 'test'
+    mixture_files = find_mixture_wavs(musdb_test)
+    print(f'Found {len(mixture_files)} mixture.wav files.')
+    print(f'Output directory: {out_dir}')
+    
+    if not mixture_files:
+        print("No mixture.wav files found. Check your --musdb-root path.")
+        return {}
+
+    # Separation with detailed timing
+    total_start = time.time()
+    total_proc_sec = 0.0
+    total_audio_sec = 0.0
+    per_track_stats = []
+    
+    skipped_count = 0
+    separated_count = 0
+    
+    for mixture_path in mixture_files:
+        rel_dir = mixture_path.parent.relative_to(musdb_test)
+        track_out_dir = out_dir / rel_dir
+        
+        # Check if track is already separated
+        if not force_reseparate and check_track_separated(track_out_dir):
+            print(f'Skipping (already separated): {mixture_path}')
+            skipped_count += 1
+            
+            # Still get audio duration for stats
+            audio_info = torchaudio.info(str(mixture_path))
+            duration_sec = audio_info.num_frames / audio_info.sample_rate
+            total_audio_sec += duration_sec
+            per_track_stats.append({
+                'track': str(rel_dir),
+                'proc_time_sec': 0.0,  # Already separated
+                'audio_duration_sec': duration_sec,
+                'skipped': True
+            })
+            continue
+        
+        track_out_dir.mkdir(parents=True, exist_ok=True)
+        print(f'Separating: {mixture_path}\n -> {track_out_dir}')
+        
+        start = time.time()
+        try:
+            separate_func(mixture_path, track_out_dir, **separate_kwargs)
+            separated_count += 1
+        except Exception as e:
+            print(f"Error processing {mixture_path}: {e}")
+            continue
+        end = time.time()
+        
+        # Get audio duration from file
+        audio_info = torchaudio.info(str(mixture_path))
+        duration_sec = audio_info.num_frames / audio_info.sample_rate
+        proc_time = end - start
+        print(f"  Track processed in {proc_time:.2f} seconds. Length: {duration_sec/60:.2f} min.")
+        
+        total_proc_sec += proc_time
+        total_audio_sec += duration_sec
+        per_track_stats.append({
+            'track': str(rel_dir),
+            'proc_time_sec': proc_time,
+            'audio_duration_sec': duration_sec,
+            'skipped': False
+        })
+    
+    total_end = time.time()
+    
+    # Print timing summary
+    print_timing_summary(total_start, total_end, total_proc_sec, total_audio_sec, 
+                         separated_count, skipped_count, len(mixture_files))
+    
+    # SI-SDR Evaluation
+    tm_scores, per_track_sisdr = evaluate_sisdr(musdb_test, out_dir, per_track_stats)
+    
+    # Create summary
+    summary = create_summary(model_identifier, len(mixture_files), total_proc_sec, 
+                           total_end - total_start, total_audio_sec, tm_scores)
+    
+    # Prepare results
+    results = {
+        'summary': summary,
+        'per_track_stats': per_track_stats,
+        'per_track_sisdr': per_track_sisdr
+    }
+    
+    # Save results
+    script_dir = Path(__file__).parent if __file__ else Path('.')
+    json_path = script_dir / json_out
+    save_results(results, json_path)
+    
+    return results

--- a/benchmark/benchmark_results_cpp.json
+++ b/benchmark/benchmark_results_cpp.json
@@ -1,0 +1,771 @@
+{
+  "summary": {
+    "model_identifier": "../onnx-models/htdemucs.ort",
+    "total_tracks": 50,
+    "total_proc_sec": 4415.296902179718,
+    "total_wall_time_sec": 4415.376672029495,
+    "total_audio_sec": 12470.980884353747,
+    "avg_time_per_min": 21.242740774557067,
+    "sisdr_mean_per_stem": {
+      "drums": 9.483649263381958,
+      "bass": 7.7968579804897304,
+      "other": 4.660999085903168,
+      "vocals": 7.82117955327034
+    },
+    "overall_sisdr_mean": 7.440671470761299
+  },
+  "per_track_stats": [
+    {
+      "track": "Moosmusic - Big Dummy Shake",
+      "proc_time_sec": 72.2551167011261,
+      "audio_duration_sec": 198.85714285714286,
+      "skipped": false
+    },
+    {
+      "track": "The Mountaineering Club - Mallory",
+      "proc_time_sec": 86.9663941860199,
+      "audio_duration_sec": 244.45981859410432,
+      "skipped": false
+    },
+    {
+      "track": "Bobby Nobody - Stitch Up",
+      "proc_time_sec": 78.90446591377258,
+      "audio_duration_sec": 221.25,
+      "skipped": false
+    },
+    {
+      "track": "Punkdisco - Oral Hygiene",
+      "proc_time_sec": 77.99546813964844,
+      "audio_duration_sec": 221.59820861678006,
+      "skipped": false
+    },
+    {
+      "track": "Lyndsey Ollard - Catching Up",
+      "proc_time_sec": 83.48380303382874,
+      "audio_duration_sec": 227.42857142857142,
+      "skipped": false
+    },
+    {
+      "track": "Al James - Schoolboy Facination",
+      "proc_time_sec": 73.81816101074219,
+      "audio_duration_sec": 200.52678004535147,
+      "skipped": false
+    },
+    {
+      "track": "James Elder & Mark M Thompson - The English Actor",
+      "proc_time_sec": 73.76609110832214,
+      "audio_duration_sec": 205.47321995464853,
+      "skipped": false
+    },
+    {
+      "track": "Juliet's Rescue - Heartbeats",
+      "proc_time_sec": 95.16558384895325,
+      "audio_duration_sec": 267.65179138322,
+      "skipped": false
+    },
+    {
+      "track": "The Easton Ellises - Falcon 69",
+      "proc_time_sec": 88.75903677940369,
+      "audio_duration_sec": 246.99065759637188,
+      "skipped": false
+    },
+    {
+      "track": "Secretariat - Borderline",
+      "proc_time_sec": 105.93883800506592,
+      "audio_duration_sec": 286.84562358276645,
+      "skipped": false
+    },
+    {
+      "track": "The Long Wait - Dark Horses",
+      "proc_time_sec": 109.58659315109253,
+      "audio_duration_sec": 305.72092970521544,
+      "skipped": false
+    },
+    {
+      "track": "Sambasevam Shanmugam - Kaathaadi",
+      "proc_time_sec": 116.18495798110962,
+      "audio_duration_sec": 317.8794557823129,
+      "skipped": false
+    },
+    {
+      "track": "Signe Jakobsen - What Have You Done To Me",
+      "proc_time_sec": 68.93309783935547,
+      "audio_duration_sec": 177.39732426303854,
+      "skipped": false
+    },
+    {
+      "track": "Girls Under Glass - We Feel Alright",
+      "proc_time_sec": 116.20321679115295,
+      "audio_duration_sec": 317.2812471655329,
+      "skipped": false
+    },
+    {
+      "track": "Mu - Too Bright",
+      "proc_time_sec": 95.77113008499146,
+      "audio_duration_sec": 272.16517006802724,
+      "skipped": false
+    },
+    {
+      "track": "Speak Softly - Broken Man",
+      "proc_time_sec": 96.770090341568,
+      "audio_duration_sec": 253.16018140589568,
+      "skipped": false
+    },
+    {
+      "track": "Georgia Wonder - Siren",
+      "proc_time_sec": 146.5136342048645,
+      "audio_duration_sec": 430.3750113378685,
+      "skipped": false
+    },
+    {
+      "track": "Arise - Run Run Run",
+      "proc_time_sec": 81.18987917900085,
+      "audio_duration_sec": 219.39285714285714,
+      "skipped": false
+    },
+    {
+      "track": "Raft Monk - Tiring",
+      "proc_time_sec": 74.97506403923035,
+      "audio_duration_sec": 212.2455328798186,
+      "skipped": false
+    },
+    {
+      "track": "M.E.R.C. Music - Knockout",
+      "proc_time_sec": 95.30466294288635,
+      "audio_duration_sec": 270.0,
+      "skipped": false
+    },
+    {
+      "track": "Triviul feat. The Fiend - Widow",
+      "proc_time_sec": 82.63730978965759,
+      "audio_duration_sec": 235.10968253968255,
+      "skipped": false
+    },
+    {
+      "track": "Tom McKenzie - Directions",
+      "proc_time_sec": 64.5309329032898,
+      "audio_duration_sec": 175.85267573696146,
+      "skipped": false
+    },
+    {
+      "track": "Timboz - Pony",
+      "proc_time_sec": 90.23408484458923,
+      "audio_duration_sec": 253.04873015873017,
+      "skipped": false
+    },
+    {
+      "track": "BKS - Bulldozer",
+      "proc_time_sec": 118.38364696502686,
+      "audio_duration_sec": 337.0401814058957,
+      "skipped": false
+    },
+    {
+      "track": "The Sunshine Garcia Band - For I Am The Moon",
+      "proc_time_sec": 109.51803708076477,
+      "audio_duration_sec": 320.2966666666667,
+      "skipped": false
+    },
+    {
+      "track": "The Easton Ellises (Baumi) - SDRNR",
+      "proc_time_sec": 78.94155406951904,
+      "audio_duration_sec": 234.68408163265306,
+      "skipped": false
+    },
+    {
+      "track": "AM Contra - Heart Peripheral",
+      "proc_time_sec": 69.50574994087219,
+      "audio_duration_sec": 210.1057596371882,
+      "skipped": false
+    },
+    {
+      "track": "The Doppler Shift - Atrophy",
+      "proc_time_sec": 109.61995220184326,
+      "audio_duration_sec": 331.44197278911565,
+      "skipped": false
+    },
+    {
+      "track": "Motor Tapes - Shore",
+      "proc_time_sec": 83.00600719451904,
+      "audio_duration_sec": 246.72321995464853,
+      "skipped": false
+    },
+    {
+      "track": "Detsky Sad - Walkie Talkie",
+      "proc_time_sec": 68.16209888458252,
+      "audio_duration_sec": 190.4821315192744,
+      "skipped": false
+    },
+    {
+      "track": "Buitraker - Revo X",
+      "proc_time_sec": 92.38999104499817,
+      "audio_duration_sec": 275.82589569160996,
+      "skipped": false
+    },
+    {
+      "track": "Little Chicago's Finest - My Own",
+      "proc_time_sec": 93.7472140789032,
+      "audio_duration_sec": 281.61160997732424,
+      "skipped": false
+    },
+    {
+      "track": "Zeno - Signs",
+      "proc_time_sec": 78.57769680023193,
+      "audio_duration_sec": 234.38392290249433,
+      "skipped": false
+    },
+    {
+      "track": "Hollow Ground - Ill Fate",
+      "proc_time_sec": 48.324772119522095,
+      "audio_duration_sec": 141.67410430839,
+      "skipped": false
+    },
+    {
+      "track": "Cristina Vane - So Easy",
+      "proc_time_sec": 85.5476279258728,
+      "audio_duration_sec": 254.13392290249433,
+      "skipped": false
+    },
+    {
+      "track": "Speak Softly - Like Horses",
+      "proc_time_sec": 103.10531830787659,
+      "audio_duration_sec": 312.6666666666667,
+      "skipped": false
+    },
+    {
+      "track": "Side Effects Project - Sing With Me",
+      "proc_time_sec": 80.40082097053528,
+      "audio_duration_sec": 243.68303854875285,
+      "skipped": false
+    },
+    {
+      "track": "Skelpolu - Resurrection",
+      "proc_time_sec": 130.4383409023285,
+      "audio_duration_sec": 395.66292517006804,
+      "skipped": false
+    },
+    {
+      "track": "Nerve 9 - Pray For The Rain",
+      "proc_time_sec": 113.63012528419495,
+      "audio_duration_sec": 343.7142857142857,
+      "skipped": false
+    },
+    {
+      "track": "Louis Cressy Band - Good Time",
+      "proc_time_sec": 107.47829914093018,
+      "audio_duration_sec": 292.82142857142856,
+      "skipped": false
+    },
+    {
+      "track": "Angels In Amplifiers - I'm Alright",
+      "proc_time_sec": 67.18869590759277,
+      "audio_duration_sec": 179.59374149659865,
+      "skipped": false
+    },
+    {
+      "track": "Ben Carrigan - We'll Talk About It All Tonight",
+      "proc_time_sec": 94.24749803543091,
+      "audio_duration_sec": 254.9107029478458,
+      "skipped": false
+    },
+    {
+      "track": "BKS - Too Much",
+      "proc_time_sec": 85.25129795074463,
+      "audio_duration_sec": 220.12498866213153,
+      "skipped": false
+    },
+    {
+      "track": "Carlos Gonzalez - A Place For Us",
+      "proc_time_sec": 94.43697500228882,
+      "audio_duration_sec": 250.21875283446713,
+      "skipped": false
+    },
+    {
+      "track": "Secretariat - Over The Top",
+      "proc_time_sec": 94.55256390571594,
+      "audio_duration_sec": 251.09587301587302,
+      "skipped": false
+    },
+    {
+      "track": "We Fell From The Sky - Not You",
+      "proc_time_sec": 84.48910403251648,
+      "audio_duration_sec": 207.89732426303854,
+      "skipped": false
+    },
+    {
+      "track": "Enda Reilly - Cur An Long Ag Seol",
+      "proc_time_sec": 72.93066787719727,
+      "audio_duration_sec": 186.9955328798186,
+      "skipped": false
+    },
+    {
+      "track": "Forkupines - Semantics",
+      "proc_time_sec": 93.40947198867798,
+      "audio_duration_sec": 273.58482993197276,
+      "skipped": false
+    },
+    {
+      "track": "PR - Happy Daze",
+      "proc_time_sec": 54.83104085922241,
+      "audio_duration_sec": 162.70222222222222,
+      "skipped": false
+    },
+    {
+      "track": "PR - Oh No",
+      "proc_time_sec": 27.294720888137817,
+      "audio_duration_sec": 76.19448979591837,
+      "skipped": false
+    }
+  ],
+  "per_track_sisdr": [
+    {
+      "track": "Moosmusic - Big Dummy Shake",
+      "sisdr": {
+        "drums": 12.076868057250977,
+        "bass": 8.487666130065918,
+        "other": 6.781095027923584,
+        "vocals": 10.804330825805664
+      }
+    },
+    {
+      "track": "The Mountaineering Club - Mallory",
+      "sisdr": {
+        "drums": 12.428815841674805,
+        "bass": 11.73557186126709,
+        "other": 7.37285041809082,
+        "vocals": 11.74293327331543
+      }
+    },
+    {
+      "track": "Bobby Nobody - Stitch Up",
+      "sisdr": {
+        "drums": 6.484430313110352,
+        "bass": 8.049901008605957,
+        "other": 5.327920913696289,
+        "vocals": 9.573049545288086
+      }
+    },
+    {
+      "track": "Punkdisco - Oral Hygiene",
+      "sisdr": {
+        "drums": 4.960267543792725,
+        "bass": 3.888305187225342,
+        "other": -0.7205855846405029,
+        "vocals": 9.480606079101562
+      }
+    },
+    {
+      "track": "Lyndsey Ollard - Catching Up",
+      "sisdr": {
+        "drums": 8.454418182373047,
+        "bass": 11.815461158752441,
+        "other": 4.866433143615723,
+        "vocals": 11.19812297821045
+      }
+    },
+    {
+      "track": "Al James - Schoolboy Facination",
+      "sisdr": {
+        "drums": 5.909154891967773,
+        "bass": 9.77098274230957,
+        "other": 1.1827776432037354,
+        "vocals": 6.552417755126953
+      }
+    },
+    {
+      "track": "James Elder & Mark M Thompson - The English Actor",
+      "sisdr": {
+        "drums": 9.831053733825684,
+        "bass": 7.396026611328125,
+        "other": 6.322834491729736,
+        "vocals": 7.00924015045166
+      }
+    },
+    {
+      "track": "Juliet's Rescue - Heartbeats",
+      "sisdr": {
+        "drums": 15.124688148498535,
+        "bass": 0.5820695161819458,
+        "other": 5.8177995681762695,
+        "vocals": 9.505229949951172
+      }
+    },
+    {
+      "track": "The Easton Ellises - Falcon 69",
+      "sisdr": {
+        "drums": 9.837166786193848,
+        "bass": 7.00649356842041,
+        "other": 2.225597381591797,
+        "vocals": 3.259247303009033
+      }
+    },
+    {
+      "track": "Secretariat - Borderline",
+      "sisdr": {
+        "drums": 6.418515205383301,
+        "bass": 4.55745267868042,
+        "other": 8.368728637695312,
+        "vocals": 7.852504730224609
+      }
+    },
+    {
+      "track": "The Long Wait - Dark Horses",
+      "sisdr": {
+        "drums": 8.357269287109375,
+        "bass": 8.272255897521973,
+        "other": 6.147729396820068,
+        "vocals": 9.22385025024414
+      }
+    },
+    {
+      "track": "Sambasevam Shanmugam - Kaathaadi",
+      "sisdr": {
+        "drums": 7.069827079772949,
+        "bass": 10.955531120300293,
+        "other": 9.52503776550293,
+        "vocals": 13.526756286621094
+      }
+    },
+    {
+      "track": "Signe Jakobsen - What Have You Done To Me",
+      "sisdr": {
+        "drums": 5.1443705558776855,
+        "bass": 2.7403550148010254,
+        "other": 5.452369689941406,
+        "vocals": 10.833425521850586
+      }
+    },
+    {
+      "track": "Girls Under Glass - We Feel Alright",
+      "sisdr": {
+        "drums": 8.375150680541992,
+        "bass": 3.9265124797821045,
+        "other": 4.777353286743164,
+        "vocals": 5.250667572021484
+      }
+    },
+    {
+      "track": "Mu - Too Bright",
+      "sisdr": {
+        "drums": 14.846909523010254,
+        "bass": 4.661462783813477,
+        "other": 5.923152923583984,
+        "vocals": 9.748008728027344
+      }
+    },
+    {
+      "track": "Speak Softly - Broken Man",
+      "sisdr": {
+        "drums": 10.293960571289062,
+        "bass": 17.542865753173828,
+        "other": 8.7847900390625,
+        "vocals": 5.811474323272705
+      }
+    },
+    {
+      "track": "Georgia Wonder - Siren",
+      "sisdr": {
+        "drums": 10.352540969848633,
+        "bass": 11.890982627868652,
+        "other": 5.833800315856934,
+        "vocals": 4.8094801902771
+      }
+    },
+    {
+      "track": "Arise - Run Run Run",
+      "sisdr": {
+        "drums": -3.5398333072662354,
+        "bass": 7.474826812744141,
+        "other": -6.429377555847168,
+        "vocals": 11.333562850952148
+      }
+    },
+    {
+      "track": "Raft Monk - Tiring",
+      "sisdr": {
+        "drums": 8.431083679199219,
+        "bass": 7.9903106689453125,
+        "other": 3.8956544399261475,
+        "vocals": 4.351275444030762
+      }
+    },
+    {
+      "track": "M.E.R.C. Music - Knockout",
+      "sisdr": {
+        "drums": 10.900727272033691,
+        "bass": 12.299074172973633,
+        "other": 5.879528999328613,
+        "vocals": 10.182559967041016
+      }
+    },
+    {
+      "track": "Triviul feat. The Fiend - Widow",
+      "sisdr": {
+        "drums": 7.442218780517578,
+        "bass": 15.901008605957031,
+        "other": 3.000394344329834,
+        "vocals": 9.54621696472168
+      }
+    },
+    {
+      "track": "Tom McKenzie - Directions",
+      "sisdr": {
+        "drums": 15.43598461151123,
+        "bass": 4.074544906616211,
+        "other": 1.278446078300476,
+        "vocals": 10.604028701782227
+      }
+    },
+    {
+      "track": "Timboz - Pony",
+      "sisdr": {
+        "drums": 3.8310978412628174,
+        "bass": 0.7721430063247681,
+        "other": 8.429235458374023,
+        "vocals": 4.071013927459717
+      }
+    },
+    {
+      "track": "BKS - Bulldozer",
+      "sisdr": {
+        "drums": 11.56806468963623,
+        "bass": 9.383036613464355,
+        "other": 5.413980960845947,
+        "vocals": 8.186647415161133
+      }
+    },
+    {
+      "track": "The Sunshine Garcia Band - For I Am The Moon",
+      "sisdr": {
+        "drums": 9.84632682800293,
+        "bass": 9.321459770202637,
+        "other": 0.9868457317352295,
+        "vocals": 9.987091064453125
+      }
+    },
+    {
+      "track": "The Easton Ellises (Baumi) - SDRNR",
+      "sisdr": {
+        "drums": 10.281189918518066,
+        "bass": 7.339255332946777,
+        "other": 1.23935866355896,
+        "vocals": 5.393749713897705
+      }
+    },
+    {
+      "track": "AM Contra - Heart Peripheral",
+      "sisdr": {
+        "drums": 7.476190567016602,
+        "bass": -3.3655803203582764,
+        "other": -9.541873931884766,
+        "vocals": 11.078791618347168
+      }
+    },
+    {
+      "track": "The Doppler Shift - Atrophy",
+      "sisdr": {
+        "drums": 8.71229362487793,
+        "bass": -0.735080897808075,
+        "other": 6.061921119689941,
+        "vocals": 8.999683380126953
+      }
+    },
+    {
+      "track": "Motor Tapes - Shore",
+      "sisdr": {
+        "drums": 8.725625038146973,
+        "bass": 11.86512279510498,
+        "other": 10.541918754577637,
+        "vocals": 8.729817390441895
+      }
+    },
+    {
+      "track": "Detsky Sad - Walkie Talkie",
+      "sisdr": {
+        "drums": 4.733802318572998,
+        "bass": 2.0718536376953125,
+        "other": 0.9726762771606445,
+        "vocals": 4.140835762023926
+      }
+    },
+    {
+      "track": "Buitraker - Revo X",
+      "sisdr": {
+        "drums": 13.86872673034668,
+        "bass": 10.904870986938477,
+        "other": 5.765130996704102,
+        "vocals": 3.6297779083251953
+      }
+    },
+    {
+      "track": "Little Chicago's Finest - My Own",
+      "sisdr": {
+        "drums": 5.780152797698975,
+        "bass": 7.849082946777344,
+        "other": -1.1176046133041382,
+        "vocals": 10.09009838104248
+      }
+    },
+    {
+      "track": "Zeno - Signs",
+      "sisdr": {
+        "drums": 9.49051284790039,
+        "bass": 1.5338236093521118,
+        "other": 6.297023773193359,
+        "vocals": 8.48747730255127
+      }
+    },
+    {
+      "track": "Hollow Ground - Ill Fate",
+      "sisdr": {
+        "drums": 5.306951522827148,
+        "bass": -3.1514086723327637,
+        "other": 2.3129231929779053,
+        "vocals": 6.978944778442383
+      }
+    },
+    {
+      "track": "Cristina Vane - So Easy",
+      "sisdr": {
+        "drums": 13.572795867919922,
+        "bass": 5.924213409423828,
+        "other": 4.605131149291992,
+        "vocals": 10.50622272491455
+      }
+    },
+    {
+      "track": "Speak Softly - Like Horses",
+      "sisdr": {
+        "drums": 7.820749282836914,
+        "bass": 22.519023895263672,
+        "other": 7.415676116943359,
+        "vocals": 8.179923057556152
+      }
+    },
+    {
+      "track": "Side Effects Project - Sing With Me",
+      "sisdr": {
+        "drums": 15.569835662841797,
+        "bass": 14.156737327575684,
+        "other": 0.5903326272964478,
+        "vocals": 12.662943840026855
+      }
+    },
+    {
+      "track": "Skelpolu - Resurrection",
+      "sisdr": {
+        "drums": 13.52575969696045,
+        "bass": 15.486486434936523,
+        "other": 4.68517541885376,
+        "vocals": -2.8216514587402344
+      }
+    },
+    {
+      "track": "Nerve 9 - Pray For The Rain",
+      "sisdr": {
+        "drums": 12.677570343017578,
+        "bass": 7.252902030944824,
+        "other": 6.955069541931152,
+        "vocals": 7.758035659790039
+      }
+    },
+    {
+      "track": "Louis Cressy Band - Good Time",
+      "sisdr": {
+        "drums": 9.123632431030273,
+        "bass": 9.534658432006836,
+        "other": 9.259672164916992,
+        "vocals": 10.050394058227539
+      }
+    },
+    {
+      "track": "Angels In Amplifiers - I'm Alright",
+      "sisdr": {
+        "drums": 6.4118971824646,
+        "bass": 10.065323829650879,
+        "other": 7.599292755126953,
+        "vocals": 10.704720497131348
+      }
+    },
+    {
+      "track": "Ben Carrigan - We'll Talk About It All Tonight",
+      "sisdr": {
+        "drums": 9.545452117919922,
+        "bass": 13.154678344726562,
+        "other": 5.548402786254883,
+        "vocals": 4.634091377258301
+      }
+    },
+    {
+      "track": "BKS - Too Much",
+      "sisdr": {
+        "drums": 9.869915008544922,
+        "bass": 13.079133987426758,
+        "other": 5.546245574951172,
+        "vocals": 11.759535789489746
+      }
+    },
+    {
+      "track": "Carlos Gonzalez - A Place For Us",
+      "sisdr": {
+        "drums": 6.42131233215332,
+        "bass": 0.2734091281890869,
+        "other": 5.855388641357422,
+        "vocals": 7.187473297119141
+      }
+    },
+    {
+      "track": "Secretariat - Over The Top",
+      "sisdr": {
+        "drums": 8.555194854736328,
+        "bass": 10.88803768157959,
+        "other": 7.318276882171631,
+        "vocals": 9.624124526977539
+      }
+    },
+    {
+      "track": "We Fell From The Sky - Not You",
+      "sisdr": {
+        "drums": 11.610185623168945,
+        "bass": 3.4700300693511963,
+        "other": 8.1987943649292,
+        "vocals": 5.945034980773926
+      }
+    },
+    {
+      "track": "Enda Reilly - Cur An Long Ag Seol",
+      "sisdr": {
+        "drums": 13.263458251953125,
+        "bass": 10.273825645446777,
+        "other": 8.334196090698242,
+        "vocals": 11.015020370483398
+      }
+    },
+    {
+      "track": "Forkupines - Semantics",
+      "sisdr": {
+        "drums": 12.45251178741455,
+        "bass": 6.549820899963379,
+        "other": 5.652408123016357,
+        "vocals": 7.858090400695801
+      }
+    },
+    {
+      "track": "PR - Happy Daze",
+      "sisdr": {
+        "drums": 19.201946258544922,
+        "bass": 10.727127075195312,
+        "other": 8.496805191040039,
+        "vocals": -5.258880615234375
+      }
+    },
+    {
+      "track": "PR - Oh No",
+      "sisdr": {
+        "drums": 10.303723335266113,
+        "bass": 1.679250717163086,
+        "other": -1.9867808818817139,
+        "vocals": -0.7190188765525818
+      }
+    }
+  ]
+}

--- a/benchmark/benchmark_results_pytorch.json
+++ b/benchmark/benchmark_results_pytorch.json
@@ -1,0 +1,771 @@
+{
+  "summary": {
+    "model_identifier": "htdemucs",
+    "total_tracks": 50,
+    "total_proc_sec": 5380.354701280594,
+    "total_wall_time_sec": 5380.692912101746,
+    "total_audio_sec": 12470.980884353747,
+    "avg_time_per_min": 25.88579720155384,
+    "sisdr_mean_per_stem": {
+      "drums": 9.495608382225036,
+      "bass": 7.86858200609684,
+      "other": 4.745085507631302,
+      "vocals": 7.901565304994583
+    },
+    "overall_sisdr_mean": 7.502710300236941
+  },
+  "per_track_stats": [
+    {
+      "track": "Moosmusic - Big Dummy Shake",
+      "proc_time_sec": 85.8320779800415,
+      "audio_duration_sec": 198.85714285714286,
+      "skipped": false
+    },
+    {
+      "track": "The Mountaineering Club - Mallory",
+      "proc_time_sec": 105.5039632320404,
+      "audio_duration_sec": 244.45981859410432,
+      "skipped": false
+    },
+    {
+      "track": "Bobby Nobody - Stitch Up",
+      "proc_time_sec": 97.79535102844238,
+      "audio_duration_sec": 221.25,
+      "skipped": false
+    },
+    {
+      "track": "Punkdisco - Oral Hygiene",
+      "proc_time_sec": 100.90690302848816,
+      "audio_duration_sec": 221.59820861678006,
+      "skipped": false
+    },
+    {
+      "track": "Lyndsey Ollard - Catching Up",
+      "proc_time_sec": 99.02986192703247,
+      "audio_duration_sec": 227.42857142857142,
+      "skipped": false
+    },
+    {
+      "track": "Al James - Schoolboy Facination",
+      "proc_time_sec": 87.05316114425659,
+      "audio_duration_sec": 200.52678004535147,
+      "skipped": false
+    },
+    {
+      "track": "James Elder & Mark M Thompson - The English Actor",
+      "proc_time_sec": 90.20261406898499,
+      "audio_duration_sec": 205.47321995464853,
+      "skipped": false
+    },
+    {
+      "track": "Juliet's Rescue - Heartbeats",
+      "proc_time_sec": 114.57546019554138,
+      "audio_duration_sec": 267.65179138322,
+      "skipped": false
+    },
+    {
+      "track": "The Easton Ellises - Falcon 69",
+      "proc_time_sec": 104.66538429260254,
+      "audio_duration_sec": 246.99065759637188,
+      "skipped": false
+    },
+    {
+      "track": "Secretariat - Borderline",
+      "proc_time_sec": 123.05995273590088,
+      "audio_duration_sec": 286.84562358276645,
+      "skipped": false
+    },
+    {
+      "track": "The Long Wait - Dark Horses",
+      "proc_time_sec": 132.9453661441803,
+      "audio_duration_sec": 305.72092970521544,
+      "skipped": false
+    },
+    {
+      "track": "Sambasevam Shanmugam - Kaathaadi",
+      "proc_time_sec": 137.9061050415039,
+      "audio_duration_sec": 317.8794557823129,
+      "skipped": false
+    },
+    {
+      "track": "Signe Jakobsen - What Have You Done To Me",
+      "proc_time_sec": 77.0567557811737,
+      "audio_duration_sec": 177.39732426303854,
+      "skipped": false
+    },
+    {
+      "track": "Girls Under Glass - We Feel Alright",
+      "proc_time_sec": 136.45311880111694,
+      "audio_duration_sec": 317.2812471655329,
+      "skipped": false
+    },
+    {
+      "track": "Mu - Too Bright",
+      "proc_time_sec": 114.78250312805176,
+      "audio_duration_sec": 272.16517006802724,
+      "skipped": false
+    },
+    {
+      "track": "Speak Softly - Broken Man",
+      "proc_time_sec": 110.23138785362244,
+      "audio_duration_sec": 253.16018140589568,
+      "skipped": false
+    },
+    {
+      "track": "Georgia Wonder - Siren",
+      "proc_time_sec": 186.40388584136963,
+      "audio_duration_sec": 430.3750113378685,
+      "skipped": false
+    },
+    {
+      "track": "Arise - Run Run Run",
+      "proc_time_sec": 93.8250150680542,
+      "audio_duration_sec": 219.39285714285714,
+      "skipped": false
+    },
+    {
+      "track": "Raft Monk - Tiring",
+      "proc_time_sec": 92.49311017990112,
+      "audio_duration_sec": 212.2455328798186,
+      "skipped": false
+    },
+    {
+      "track": "M.E.R.C. Music - Knockout",
+      "proc_time_sec": 116.4765841960907,
+      "audio_duration_sec": 270.0,
+      "skipped": false
+    },
+    {
+      "track": "Triviul feat. The Fiend - Widow",
+      "proc_time_sec": 102.9729437828064,
+      "audio_duration_sec": 235.10968253968255,
+      "skipped": false
+    },
+    {
+      "track": "Tom McKenzie - Directions",
+      "proc_time_sec": 77.48358678817749,
+      "audio_duration_sec": 175.85267573696146,
+      "skipped": false
+    },
+    {
+      "track": "Timboz - Pony",
+      "proc_time_sec": 111.19315981864929,
+      "audio_duration_sec": 253.04873015873017,
+      "skipped": false
+    },
+    {
+      "track": "BKS - Bulldozer",
+      "proc_time_sec": 146.85132384300232,
+      "audio_duration_sec": 337.0401814058957,
+      "skipped": false
+    },
+    {
+      "track": "The Sunshine Garcia Band - For I Am The Moon",
+      "proc_time_sec": 139.27941799163818,
+      "audio_duration_sec": 320.2966666666667,
+      "skipped": false
+    },
+    {
+      "track": "The Easton Ellises (Baumi) - SDRNR",
+      "proc_time_sec": 102.85355401039124,
+      "audio_duration_sec": 234.68408163265306,
+      "skipped": false
+    },
+    {
+      "track": "AM Contra - Heart Peripheral",
+      "proc_time_sec": 89.79055905342102,
+      "audio_duration_sec": 210.1057596371882,
+      "skipped": false
+    },
+    {
+      "track": "The Doppler Shift - Atrophy",
+      "proc_time_sec": 142.50873494148254,
+      "audio_duration_sec": 331.44197278911565,
+      "skipped": false
+    },
+    {
+      "track": "Motor Tapes - Shore",
+      "proc_time_sec": 105.83078598976135,
+      "audio_duration_sec": 246.72321995464853,
+      "skipped": false
+    },
+    {
+      "track": "Detsky Sad - Walkie Talkie",
+      "proc_time_sec": 81.48389410972595,
+      "audio_duration_sec": 190.4821315192744,
+      "skipped": false
+    },
+    {
+      "track": "Buitraker - Revo X",
+      "proc_time_sec": 121.82760190963745,
+      "audio_duration_sec": 275.82589569160996,
+      "skipped": false
+    },
+    {
+      "track": "Little Chicago's Finest - My Own",
+      "proc_time_sec": 124.12358808517456,
+      "audio_duration_sec": 281.61160997732424,
+      "skipped": false
+    },
+    {
+      "track": "Zeno - Signs",
+      "proc_time_sec": 102.4804699420929,
+      "audio_duration_sec": 234.38392290249433,
+      "skipped": false
+    },
+    {
+      "track": "Hollow Ground - Ill Fate",
+      "proc_time_sec": 61.8152379989624,
+      "audio_duration_sec": 141.67410430839,
+      "skipped": false
+    },
+    {
+      "track": "Cristina Vane - So Easy",
+      "proc_time_sec": 109.08313202857971,
+      "audio_duration_sec": 254.13392290249433,
+      "skipped": false
+    },
+    {
+      "track": "Speak Softly - Like Horses",
+      "proc_time_sec": 135.4605770111084,
+      "audio_duration_sec": 312.6666666666667,
+      "skipped": false
+    },
+    {
+      "track": "Side Effects Project - Sing With Me",
+      "proc_time_sec": 102.4015109539032,
+      "audio_duration_sec": 243.68303854875285,
+      "skipped": false
+    },
+    {
+      "track": "Skelpolu - Resurrection",
+      "proc_time_sec": 169.12373399734497,
+      "audio_duration_sec": 395.66292517006804,
+      "skipped": false
+    },
+    {
+      "track": "Nerve 9 - Pray For The Rain",
+      "proc_time_sec": 145.17578101158142,
+      "audio_duration_sec": 343.7142857142857,
+      "skipped": false
+    },
+    {
+      "track": "Louis Cressy Band - Good Time",
+      "proc_time_sec": 126.29039907455444,
+      "audio_duration_sec": 292.82142857142856,
+      "skipped": false
+    },
+    {
+      "track": "Angels In Amplifiers - I'm Alright",
+      "proc_time_sec": 76.5743658542633,
+      "audio_duration_sec": 179.59374149659865,
+      "skipped": false
+    },
+    {
+      "track": "Ben Carrigan - We'll Talk About It All Tonight",
+      "proc_time_sec": 108.40188002586365,
+      "audio_duration_sec": 254.9107029478458,
+      "skipped": false
+    },
+    {
+      "track": "BKS - Too Much",
+      "proc_time_sec": 92.8764579296112,
+      "audio_duration_sec": 220.12498866213153,
+      "skipped": false
+    },
+    {
+      "track": "Carlos Gonzalez - A Place For Us",
+      "proc_time_sec": 106.27772688865662,
+      "audio_duration_sec": 250.21875283446713,
+      "skipped": false
+    },
+    {
+      "track": "Secretariat - Over The Top",
+      "proc_time_sec": 105.20746898651123,
+      "audio_duration_sec": 251.09587301587302,
+      "skipped": false
+    },
+    {
+      "track": "We Fell From The Sky - Not You",
+      "proc_time_sec": 88.88515877723694,
+      "audio_duration_sec": 207.89732426303854,
+      "skipped": false
+    },
+    {
+      "track": "Enda Reilly - Cur An Long Ag Seol",
+      "proc_time_sec": 78.14656376838684,
+      "audio_duration_sec": 186.9955328798186,
+      "skipped": false
+    },
+    {
+      "track": "Forkupines - Semantics",
+      "proc_time_sec": 115.1323938369751,
+      "audio_duration_sec": 273.58482993197276,
+      "skipped": false
+    },
+    {
+      "track": "PR - Happy Daze",
+      "proc_time_sec": 68.88173007965088,
+      "audio_duration_sec": 162.70222222222222,
+      "skipped": false
+    },
+    {
+      "track": "PR - Oh No",
+      "proc_time_sec": 34.742401123046875,
+      "audio_duration_sec": 76.19448979591837,
+      "skipped": false
+    }
+  ],
+  "per_track_sisdr": [
+    {
+      "track": "Moosmusic - Big Dummy Shake",
+      "sisdr": {
+        "drums": 12.071355819702148,
+        "bass": 8.516130447387695,
+        "other": 6.7957353591918945,
+        "vocals": 10.828594207763672
+      }
+    },
+    {
+      "track": "The Mountaineering Club - Mallory",
+      "sisdr": {
+        "drums": 12.460540771484375,
+        "bass": 11.6375093460083,
+        "other": 7.326452255249023,
+        "vocals": 11.828144073486328
+      }
+    },
+    {
+      "track": "Bobby Nobody - Stitch Up",
+      "sisdr": {
+        "drums": 6.5583343505859375,
+        "bass": 8.150527954101562,
+        "other": 5.398844242095947,
+        "vocals": 9.583775520324707
+      }
+    },
+    {
+      "track": "Punkdisco - Oral Hygiene",
+      "sisdr": {
+        "drums": 4.9525556564331055,
+        "bass": 3.819638252258301,
+        "other": -0.7829687595367432,
+        "vocals": 9.583642959594727
+      }
+    },
+    {
+      "track": "Lyndsey Ollard - Catching Up",
+      "sisdr": {
+        "drums": 8.46963882446289,
+        "bass": 11.831181526184082,
+        "other": 5.088103294372559,
+        "vocals": 11.481330871582031
+      }
+    },
+    {
+      "track": "Al James - Schoolboy Facination",
+      "sisdr": {
+        "drums": 5.910382270812988,
+        "bass": 9.797395706176758,
+        "other": 1.2608473300933838,
+        "vocals": 6.650204658508301
+      }
+    },
+    {
+      "track": "James Elder & Mark M Thompson - The English Actor",
+      "sisdr": {
+        "drums": 9.853202819824219,
+        "bass": 7.555763244628906,
+        "other": 6.384685516357422,
+        "vocals": 7.06732177734375
+      }
+    },
+    {
+      "track": "Juliet's Rescue - Heartbeats",
+      "sisdr": {
+        "drums": 15.151365280151367,
+        "bass": 0.6509783267974854,
+        "other": 5.861086845397949,
+        "vocals": 9.491674423217773
+      }
+    },
+    {
+      "track": "The Easton Ellises - Falcon 69",
+      "sisdr": {
+        "drums": 9.834739685058594,
+        "bass": 6.977230072021484,
+        "other": 2.3127431869506836,
+        "vocals": 3.386789321899414
+      }
+    },
+    {
+      "track": "Secretariat - Borderline",
+      "sisdr": {
+        "drums": 6.428416728973389,
+        "bass": 4.567793846130371,
+        "other": 8.380098342895508,
+        "vocals": 7.872800350189209
+      }
+    },
+    {
+      "track": "The Long Wait - Dark Horses",
+      "sisdr": {
+        "drums": 8.36652946472168,
+        "bass": 8.23952865600586,
+        "other": 6.150683879852295,
+        "vocals": 9.208308219909668
+      }
+    },
+    {
+      "track": "Sambasevam Shanmugam - Kaathaadi",
+      "sisdr": {
+        "drums": 7.080286502838135,
+        "bass": 10.937719345092773,
+        "other": 9.473913192749023,
+        "vocals": 13.43853759765625
+      }
+    },
+    {
+      "track": "Signe Jakobsen - What Have You Done To Me",
+      "sisdr": {
+        "drums": 5.113121032714844,
+        "bass": 2.8725156784057617,
+        "other": 5.539188861846924,
+        "vocals": 10.834498405456543
+      }
+    },
+    {
+      "track": "Girls Under Glass - We Feel Alright",
+      "sisdr": {
+        "drums": 8.407491683959961,
+        "bass": 3.989732027053833,
+        "other": 4.840655326843262,
+        "vocals": 5.244880676269531
+      }
+    },
+    {
+      "track": "Mu - Too Bright",
+      "sisdr": {
+        "drums": 14.869138717651367,
+        "bass": 4.363337516784668,
+        "other": 5.76539421081543,
+        "vocals": 9.757135391235352
+      }
+    },
+    {
+      "track": "Speak Softly - Broken Man",
+      "sisdr": {
+        "drums": 10.576001167297363,
+        "bass": 17.6278133392334,
+        "other": 8.895854949951172,
+        "vocals": 5.7192769050598145
+      }
+    },
+    {
+      "track": "Georgia Wonder - Siren",
+      "sisdr": {
+        "drums": 10.344594955444336,
+        "bass": 11.889883995056152,
+        "other": 5.8512282371521,
+        "vocals": 4.859372138977051
+      }
+    },
+    {
+      "track": "Arise - Run Run Run",
+      "sisdr": {
+        "drums": -3.5452518463134766,
+        "bass": 7.387389183044434,
+        "other": -6.443785667419434,
+        "vocals": 11.32826042175293
+      }
+    },
+    {
+      "track": "Raft Monk - Tiring",
+      "sisdr": {
+        "drums": 8.472747802734375,
+        "bass": 8.174470901489258,
+        "other": 4.056208610534668,
+        "vocals": 4.447052478790283
+      }
+    },
+    {
+      "track": "M.E.R.C. Music - Knockout",
+      "sisdr": {
+        "drums": 10.872469902038574,
+        "bass": 12.384363174438477,
+        "other": 5.881858825683594,
+        "vocals": 10.190458297729492
+      }
+    },
+    {
+      "track": "Triviul feat. The Fiend - Widow",
+      "sisdr": {
+        "drums": 7.513405799865723,
+        "bass": 15.896966934204102,
+        "other": 3.0435099601745605,
+        "vocals": 9.551450729370117
+      }
+    },
+    {
+      "track": "Tom McKenzie - Directions",
+      "sisdr": {
+        "drums": 15.478045463562012,
+        "bass": 4.27455997467041,
+        "other": 1.362399935722351,
+        "vocals": 10.609475135803223
+      }
+    },
+    {
+      "track": "Timboz - Pony",
+      "sisdr": {
+        "drums": 3.8443191051483154,
+        "bass": 0.7741499543190002,
+        "other": 8.417970657348633,
+        "vocals": 4.045088768005371
+      }
+    },
+    {
+      "track": "BKS - Bulldozer",
+      "sisdr": {
+        "drums": 11.541387557983398,
+        "bass": 9.328031539916992,
+        "other": 5.411253929138184,
+        "vocals": 8.228431701660156
+      }
+    },
+    {
+      "track": "The Sunshine Garcia Band - For I Am The Moon",
+      "sisdr": {
+        "drums": 9.758296966552734,
+        "bass": 9.189159393310547,
+        "other": 1.0513253211975098,
+        "vocals": 10.121541023254395
+      }
+    },
+    {
+      "track": "The Easton Ellises (Baumi) - SDRNR",
+      "sisdr": {
+        "drums": 10.246496200561523,
+        "bass": 7.327853202819824,
+        "other": 1.2332955598831177,
+        "vocals": 5.3851318359375
+      }
+    },
+    {
+      "track": "AM Contra - Heart Peripheral",
+      "sisdr": {
+        "drums": 7.5877275466918945,
+        "bass": -3.223369836807251,
+        "other": -9.380182266235352,
+        "vocals": 11.101865768432617
+      }
+    },
+    {
+      "track": "The Doppler Shift - Atrophy",
+      "sisdr": {
+        "drums": 8.6489896774292,
+        "bass": -0.6417782306671143,
+        "other": 5.955848693847656,
+        "vocals": 9.003110885620117
+      }
+    },
+    {
+      "track": "Motor Tapes - Shore",
+      "sisdr": {
+        "drums": 8.734582901000977,
+        "bass": 11.947744369506836,
+        "other": 10.670381546020508,
+        "vocals": 8.900548934936523
+      }
+    },
+    {
+      "track": "Detsky Sad - Walkie Talkie",
+      "sisdr": {
+        "drums": 4.822718620300293,
+        "bass": 2.5616345405578613,
+        "other": 0.8252473473548889,
+        "vocals": 4.166924476623535
+      }
+    },
+    {
+      "track": "Buitraker - Revo X",
+      "sisdr": {
+        "drums": 13.84811782836914,
+        "bass": 10.927193641662598,
+        "other": 5.7379469871521,
+        "vocals": 3.5879335403442383
+      }
+    },
+    {
+      "track": "Little Chicago's Finest - My Own",
+      "sisdr": {
+        "drums": 5.696103572845459,
+        "bass": 6.817224502563477,
+        "other": -2.0025811195373535,
+        "vocals": 9.841245651245117
+      }
+    },
+    {
+      "track": "Zeno - Signs",
+      "sisdr": {
+        "drums": 9.51219367980957,
+        "bass": 1.7389603853225708,
+        "other": 6.339296340942383,
+        "vocals": 8.457992553710938
+      }
+    },
+    {
+      "track": "Hollow Ground - Ill Fate",
+      "sisdr": {
+        "drums": 5.31204891204834,
+        "bass": -0.1181962788105011,
+        "other": 5.483057975769043,
+        "vocals": 6.969854354858398
+      }
+    },
+    {
+      "track": "Cristina Vane - So Easy",
+      "sisdr": {
+        "drums": 13.592769622802734,
+        "bass": 5.9485321044921875,
+        "other": 4.645576477050781,
+        "vocals": 10.53253173828125
+      }
+    },
+    {
+      "track": "Speak Softly - Like Horses",
+      "sisdr": {
+        "drums": 7.819828033447266,
+        "bass": 22.087650299072266,
+        "other": 7.404175758361816,
+        "vocals": 8.187697410583496
+      }
+    },
+    {
+      "track": "Side Effects Project - Sing With Me",
+      "sisdr": {
+        "drums": 15.629430770874023,
+        "bass": 14.210481643676758,
+        "other": 0.6223646402359009,
+        "vocals": 12.644596099853516
+      }
+    },
+    {
+      "track": "Skelpolu - Resurrection",
+      "sisdr": {
+        "drums": 13.41352653503418,
+        "bass": 15.36403751373291,
+        "other": 4.829902172088623,
+        "vocals": -2.1091394424438477
+      }
+    },
+    {
+      "track": "Nerve 9 - Pray For The Rain",
+      "sisdr": {
+        "drums": 12.684746742248535,
+        "bass": 7.265007972717285,
+        "other": 7.006416320800781,
+        "vocals": 7.823451995849609
+      }
+    },
+    {
+      "track": "Louis Cressy Band - Good Time",
+      "sisdr": {
+        "drums": 9.140345573425293,
+        "bass": 9.558309555053711,
+        "other": 9.277826309204102,
+        "vocals": 10.02309799194336
+      }
+    },
+    {
+      "track": "Angels In Amplifiers - I'm Alright",
+      "sisdr": {
+        "drums": 6.459205627441406,
+        "bass": 10.079222679138184,
+        "other": 7.621806621551514,
+        "vocals": 10.718986511230469
+      }
+    },
+    {
+      "track": "Ben Carrigan - We'll Talk About It All Tonight",
+      "sisdr": {
+        "drums": 9.559080123901367,
+        "bass": 13.219244956970215,
+        "other": 5.549617767333984,
+        "vocals": 4.604496002197266
+      }
+    },
+    {
+      "track": "BKS - Too Much",
+      "sisdr": {
+        "drums": 9.910055160522461,
+        "bass": 13.087109565734863,
+        "other": 5.652220726013184,
+        "vocals": 11.74988079071045
+      }
+    },
+    {
+      "track": "Carlos Gonzalez - A Place For Us",
+      "sisdr": {
+        "drums": 6.39599084854126,
+        "bass": 0.43177473545074463,
+        "other": 5.931334972381592,
+        "vocals": 7.24365234375
+      }
+    },
+    {
+      "track": "Secretariat - Over The Top",
+      "sisdr": {
+        "drums": 8.569833755493164,
+        "bass": 10.962817192077637,
+        "other": 7.403019905090332,
+        "vocals": 9.657123565673828
+      }
+    },
+    {
+      "track": "We Fell From The Sky - Not You",
+      "sisdr": {
+        "drums": 11.612286567687988,
+        "bass": 3.503507614135742,
+        "other": 8.191743850708008,
+        "vocals": 5.936749458312988
+      }
+    },
+    {
+      "track": "Enda Reilly - Cur An Long Ag Seol",
+      "sisdr": {
+        "drums": 13.243928909301758,
+        "bass": 10.275108337402344,
+        "other": 8.407516479492188,
+        "vocals": 11.143491744995117
+      }
+    },
+    {
+      "track": "Forkupines - Semantics",
+      "sisdr": {
+        "drums": 12.45689582824707,
+        "bass": 6.553016662597656,
+        "other": 5.631094455718994,
+        "vocals": 7.846885681152344
+      }
+    },
+    {
+      "track": "PR - Happy Daze",
+      "sisdr": {
+        "drums": 19.1263427734375,
+        "bass": 10.518094062805176,
+        "other": 8.650130271911621,
+        "vocals": -3.117940664291382
+      }
+    },
+    {
+      "track": "PR - Oh No",
+      "sisdr": {
+        "drums": 10.374056816101074,
+        "bass": 2.1941487789154053,
+        "other": -1.7560702562332153,
+        "vocals": -0.5799500346183777
+      }
+    }
+  ]
+}

--- a/cppscripts/Makefile
+++ b/cppscripts/Makefile
@@ -1,0 +1,15 @@
+default: cli
+
+cli:
+	cmake -S src_cli -B build/build-cli -DCMAKE_BUILD_TYPE=Release
+	cmake --build build/build-cli -- -j16
+
+cli-debug:
+	cmake -S src_cli -B build/build-cli -DCMAKE_BUILD_TYPE=Debug
+	cmake --build build/build-cli -- -j16
+
+clean-all:
+	rm -rf build
+
+clean-cli:
+	rm -rf build/build-cli

--- a/cppscripts/src/demucs.hpp
+++ b/cppscripts/src/demucs.hpp
@@ -1,0 +1,132 @@
+#ifndef MODEL_HPP
+#define MODEL_HPP
+
+#include "dsp.hpp"
+#include "tensor.hpp"
+#include <Eigen/Dense>
+#include <array>
+#include <functional>
+#include <iostream>
+#include <string>
+#include <vector>
+#include <onnxruntime/onnxruntime_cxx_api.h>
+
+namespace demucsonnx
+{
+extern Ort::AllocatorWithDefaultOptions allocator;
+extern Ort::RunOptions run_options;
+
+// Define a type for your callback function
+using ProgressCallback = std::function<void(float, const std::string &)>;
+
+const int FREQ_BRANCH_LEN = 336;
+const int TIME_BRANCH_LEN_IN = 343980;
+
+struct demucs_model {
+    std::unique_ptr<Ort::Session> sess;        // Smart pointer to allow "empty" state
+    int nb_sources = 0;
+    Ort::Env env{ORT_LOGGING_LEVEL_ERROR, "demucs_onnx"}; // Persistent environment
+    std::vector<std::string> input_names;      // Persistent input names
+    std::vector<std::string> output_names;     // Persistent output names
+
+    std::vector<const char*> input_names_ptrs;
+    std::vector<const char*> output_names_ptrs;
+
+    // Constructor (optionally initialize here if needed)
+    demucs_model() = default;
+};
+
+bool load_model(const char *model_data,
+                int n_bytes,
+                struct demucs_model &model,
+                Ort::SessionOptions &session_options);
+
+bool load_model(const std::vector<char> &model_data,
+                struct demucs_model &model,
+                Ort::SessionOptions &session_options);
+
+struct demucs_segment_buffers
+{
+    int segment_samples;
+    int le;
+    int pad;
+    int pad_end;
+    int padded_segment_samples;
+    int nb_stft_frames;
+    int nb_stft_bins;
+
+    Eigen::Tensor3dXf targets_out;
+    Eigen::MatrixXf padded_mix;
+    Eigen::Tensor3dXcf z;
+
+    std::vector<int64_t> x_onnx_in_shape;
+    std::vector<int64_t> xt_onnx_in_shape;
+
+    std::vector<int64_t> x_onnx_out_shape;
+    std::vector<int64_t> xt_onnx_out_shape;
+
+    std::vector<Ort::Value> input_tensors;
+    std::vector<Ort::Value> output_tensors;
+
+    // constructor for demucs_segment_buffers that takes int parameters
+
+    // let's do pesky precomputing of the signal repadding to 1/4 hop
+    // for time and frequency alignment
+    demucs_segment_buffers(int nb_channels, int segment_samples, int nb_sources)
+        : segment_samples(segment_samples),
+          le(int(std::ceil((float)segment_samples / (float)FFT_HOP_SIZE))),
+          pad(std::floor((float)FFT_HOP_SIZE / 2.0f) * 3),
+          pad_end(pad + le * FFT_HOP_SIZE - segment_samples),
+          padded_segment_samples(segment_samples + pad + pad_end),
+          nb_stft_frames(segment_samples / demucsonnx::FFT_HOP_SIZE + 1),
+          nb_stft_bins(demucsonnx::FFT_WINDOW_SIZE / 2 + 1),
+          targets_out(nb_sources, nb_channels, segment_samples),
+          padded_mix(nb_channels, padded_segment_samples),
+          z(nb_channels, nb_stft_bins, nb_stft_frames+4),
+          // complex-as-channels implies 2*nb_channels for real+imag
+          x_onnx_in_shape({1, 2 * nb_channels, nb_stft_bins - 1, nb_stft_frames}),
+          xt_onnx_in_shape({1, nb_channels, segment_samples}),
+          x_onnx_out_shape({1, nb_sources, 2 * nb_channels, nb_stft_bins - 1, nb_stft_frames}),
+          xt_onnx_out_shape({1, nb_sources, nb_channels, segment_samples})
+    {
+        // precompute the input tensors
+        // inputs in form (xt, x)
+        input_tensors.push_back(Ort::Value::CreateTensor<float>(
+            demucsonnx::allocator,
+            xt_onnx_in_shape.data(),
+            xt_onnx_in_shape.size()));
+
+        // input_tensors.push_back(Ort::Value::CreateTensor<float>(
+        //     demucsonnx::allocator,
+        //     x_onnx_in_shape.data(),
+        //     x_onnx_in_shape.size()));
+
+        // precompute the output tensors
+        // outputs in form (x_out, xt_out)
+        // output_tensors.push_back(Ort::Value::CreateTensor<float>(
+        //     demucsonnx::allocator,
+        //     x_onnx_out_shape.data(),
+        //     x_onnx_out_shape.size()));
+
+        output_tensors.push_back(Ort::Value::CreateTensor<float>(
+            demucsonnx::allocator,
+            xt_onnx_out_shape.data(),
+            xt_onnx_out_shape.size()));
+    };
+};
+
+const float SEGMENT_LEN_SECS = 7.8;      // 8 seconds, the demucs chunk size
+const float SEGMENT_OVERLAP_SECS = 0.25; // 0.25 overlap
+const float MAX_SHIFT_SECS = 0.5;        // max shift
+const float OVERLAP = 0.25;              // overlap between segments
+const float TRANSITION_POWER = 1.0;      // transition between segments
+
+Eigen::Tensor3dXf demucs_inference(struct demucs_model &model,
+                                   const Eigen::MatrixXf &audio,
+                                   ProgressCallback cb);
+
+void model_inference(struct demucs_model &model,
+                     struct demucsonnx::demucs_segment_buffers &buffers);
+} // namespace demucsonnx
+
+#endif // MODEL_HPP

--- a/cppscripts/src/dsp.cpp
+++ b/cppscripts/src/dsp.cpp
@@ -1,0 +1,191 @@
+#include "dsp.hpp"
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <unsupported/Eigen/FFT>
+#include <vector>
+
+// forward declaration of inner stft
+void stft_inner(struct demucsonnx::stft_buffers &stft_buf,
+                Eigen::FFT<float> &cfg);
+
+void istft_inner(struct demucsonnx::stft_buffers &stft_buf,
+                 Eigen::FFT<float> &cfg);
+
+// reflect padding
+void pad_signal(struct demucsonnx::stft_buffers &stft_buf)
+{
+    // copy from stft_buf.padded_waveform_mono_in+pad into stft_buf.pad_start,
+    // stft_buf.pad_end
+    std::copy_n(stft_buf.padded_waveform_mono_in.begin() + stft_buf.pad,
+                stft_buf.pad, stft_buf.pad_start.begin());
+    std::copy_n(stft_buf.padded_waveform_mono_in.end() - 2 * stft_buf.pad,
+                stft_buf.pad, stft_buf.pad_end.begin());
+
+    std::reverse(stft_buf.pad_start.begin(), stft_buf.pad_start.end());
+    std::reverse(stft_buf.pad_end.begin(), stft_buf.pad_end.end());
+
+    // copy stft_buf.pad_start into stft_buf.padded_waveform_mono_in
+    std::copy_n(stft_buf.pad_start.begin(), stft_buf.pad,
+                stft_buf.padded_waveform_mono_in.begin());
+
+    // copy stft_buf.pad_end into stft_buf.padded_waveform_mono_in
+    std::copy_n(stft_buf.pad_end.begin(), stft_buf.pad,
+                stft_buf.padded_waveform_mono_in.end() - stft_buf.pad);
+}
+
+Eigen::FFT<float> get_fft_cfg()
+{
+    Eigen::FFT<float> cfg;
+
+    cfg.SetFlag(Eigen::FFT<float>::Speedy);
+    // cfg.SetFlag(Eigen::FFT<float>::HalfSpectrum);
+    // cfg.SetFlag(Eigen::FFT<float>::Unscaled);
+
+    return cfg;
+}
+
+void demucsonnx::stft(
+    struct stft_buffers &stft_buf,
+    const Eigen::MatrixXf &waveform,
+    Eigen::Tensor3dXcf &spec)
+{
+    // get the fft config
+    Eigen::FFT<float> cfg = get_fft_cfg();
+
+    /*****************************************/
+    /*  operate on each channel sequentially */
+    /*****************************************/
+
+    for (int channel = 0; channel < 2; ++channel)
+    {
+        Eigen::VectorXf row_vec = waveform.row(channel);
+
+        std::copy_n(row_vec.data(), row_vec.size(),
+                    stft_buf.padded_waveform_mono_in.begin() + stft_buf.pad);
+
+        // apply padding equivalent to center padding with center=True
+        // in torch.stft:
+        // https://pytorch.org/docs/stable/generated/torch.stft.html
+
+        // reflect pads stft_buf.padded_waveform_mono in-place
+        pad_signal(stft_buf);
+
+        // does forward fft on stft_buf.padded_waveform_mono, stores spectrum in
+        // complex_spec_mono
+        stft_inner(stft_buf, cfg);
+
+        for (int i = 0; i < stft_buf.nb_bins; ++i)
+        {
+            for (int j = 0; j < stft_buf.nb_frames; ++j)
+            {
+                spec(channel, i, j) = stft_buf.complex_spec_mono[j][i];
+            }
+        }
+    }
+}
+
+void demucsonnx::istft(
+    struct stft_buffers &stft_buf,
+    const Eigen::Tensor3dXcf &spec,
+    Eigen::MatrixXf &waveform)
+{
+    // get the fft config
+    Eigen::FFT<float> cfg = get_fft_cfg();
+
+    /*****************************************/
+    /*  operate on each channel sequentially */
+    /*****************************************/
+
+    for (int channel = 0; channel < 2; ++channel)
+    {
+        // Populate the nested vectors
+        for (int i = 0; i < stft_buf.nb_bins; ++i)
+        {
+            for (int j = 0; j < stft_buf.nb_frames; ++j)
+            {
+                stft_buf.complex_spec_mono[j][i] = spec(channel, i, j);
+            }
+        }
+
+        // does inverse fft on stft_buf.complex_spec_mono, stores waveform in
+        // padded_waveform_mono
+        istft_inner(stft_buf, cfg);
+
+        // copies waveform_mono into stft_buf.waveform past first pad samples
+        waveform.row(channel) = Eigen::Map<Eigen::MatrixXf>(
+            stft_buf.padded_waveform_mono_out.data() + stft_buf.pad, 1,
+            stft_buf.padded_waveform_mono_out.size() - FFT_WINDOW_SIZE);
+    }
+}
+
+void stft_inner(struct demucsonnx::stft_buffers &stft_buf,
+                Eigen::FFT<float> &cfg)
+{
+    int frame_idx = 0;
+
+    // Loop over the waveform with a stride of hop_size
+    for (std::size_t start = 0;
+         start <=
+         stft_buf.padded_waveform_mono_in.size() - demucsonnx::FFT_WINDOW_SIZE;
+         start += demucsonnx::FFT_HOP_SIZE)
+    {
+        // Apply window and run FFT
+        for (int i = 0; i < demucsonnx::FFT_WINDOW_SIZE; ++i)
+        {
+            stft_buf.windowed_waveform_mono[i] =
+                stft_buf.padded_waveform_mono_in[start + i] *
+                stft_buf.window[i];
+        }
+        cfg.fwd(stft_buf.complex_spec_mono[frame_idx],
+                stft_buf.windowed_waveform_mono);
+        // now scale stft_buf.complex_spec_mono[frame_idx] by 1.0f /
+        // sqrt(float(FFT_WINDOW_SIZE)))
+
+        for (int i = 0; i < demucsonnx::FFT_WINDOW_SIZE / 2 + 1; ++i)
+        {
+            stft_buf.complex_spec_mono[frame_idx][i] *=
+                1.0f / sqrt(float(demucsonnx::FFT_WINDOW_SIZE));
+        }
+        frame_idx++;
+    }
+}
+
+void istft_inner(struct demucsonnx::stft_buffers &stft_buf,
+                 Eigen::FFT<float> &cfg)
+{
+    // clear padded_waveform_mono
+    std::fill(stft_buf.padded_waveform_mono_out.begin(),
+              stft_buf.padded_waveform_mono_out.end(), 0.0f);
+
+    // Loop over the input with a stride of (hop_size)
+    for (int start = 0; start < stft_buf.nb_frames * demucsonnx::FFT_HOP_SIZE;
+         start += demucsonnx::FFT_HOP_SIZE)
+    {
+        int frame_idx = start / demucsonnx::FFT_HOP_SIZE;
+        // undo sqrt(nfft) scaling
+        for (int i = 0; i < demucsonnx::FFT_WINDOW_SIZE / 2 + 1; ++i)
+        {
+            stft_buf.complex_spec_mono[frame_idx][i] *=
+                sqrt(float(demucsonnx::FFT_WINDOW_SIZE));
+        }
+        // Run iFFT
+        cfg.inv(stft_buf.windowed_waveform_mono,
+                stft_buf.complex_spec_mono[frame_idx]);
+
+        // Apply window and add to output
+        for (int i = 0; i < demucsonnx::FFT_WINDOW_SIZE; ++i)
+        {
+            // x[start+i] is the sum of squared window values
+            // https://github.com/librosa/librosa/blob/main/librosa/core/spectrum.py#L613
+            // 1e-8f is a small number to avoid division by zero
+            stft_buf.padded_waveform_mono_out[start + i] +=
+                stft_buf.windowed_waveform_mono[i] * stft_buf.window[i] * 1.0f /
+                float(demucsonnx::FFT_WINDOW_SIZE) /
+                (stft_buf.normalized_window[start + i] + 1e-8f);
+        }
+    }
+}

--- a/cppscripts/src/dsp.hpp
+++ b/cppscripts/src/dsp.hpp
@@ -1,0 +1,109 @@
+#ifndef DSP_HPP
+#define DSP_HPP
+
+#include <Eigen/Dense>
+#include <complex>
+#include <iostream>
+#include <string>
+#include <tensor.hpp>
+#include <unsupported/Eigen/FFT>
+#include <vector>
+
+namespace demucsonnx
+{
+
+const int SUPPORTED_SAMPLE_RATE = 44100;
+const int FFT_WINDOW_SIZE = 4096;
+
+const int FFT_HOP_SIZE = 1024; // 25% hop i.e. 75% overlap
+
+struct stft_buffers
+{
+    int nb_frames;
+    int nb_bins;
+    int pad;
+
+    const std::vector<float> window;
+    const std::vector<float> normalized_window;
+
+    std::vector<float> pad_start;
+    std::vector<float> pad_end;
+    std::vector<float> padded_waveform_mono_in;
+    std::vector<float> padded_waveform_mono_out;
+    std::vector<float> windowed_waveform_mono;
+
+    std::vector<std::vector<std::complex<float>>> complex_spec_mono;
+
+    // constructor for stft_buffers that takes some parameters
+    // to hint at the sizes of the buffers
+    explicit stft_buffers(int n_samples)
+        : nb_frames(n_samples / FFT_HOP_SIZE + 1),
+          nb_bins(FFT_WINDOW_SIZE / 2 + 1), pad(FFT_WINDOW_SIZE / 2),
+          window(init_const_hann_window()),
+          normalized_window(init_const_normalized_window(window, nb_frames)),
+          pad_start(std::vector<float>(pad)), pad_end(std::vector<float>(pad)),
+          padded_waveform_mono_in(
+              std::vector<float>(n_samples + FFT_WINDOW_SIZE)),
+          padded_waveform_mono_out(
+              std::vector<float>(n_samples + FFT_WINDOW_SIZE)),
+          windowed_waveform_mono(std::vector<float>(FFT_WINDOW_SIZE)),
+          complex_spec_mono(std::vector<std::vector<std::complex<float>>>(
+              nb_frames, std::vector<std::complex<float>>(nb_bins))){};
+
+    static std::vector<float> init_const_hann_window()
+    {
+        static constexpr float PI = 3.14159265359F;
+        std::vector<float> window(FFT_WINDOW_SIZE);
+
+        // create a periodic hann window
+        // by generating L+1 points and deleting the last one
+        auto floatN = (float)(FFT_WINDOW_SIZE + 1);
+
+        for (std::size_t n = 0; n < FFT_WINDOW_SIZE; ++n)
+        {
+            window[n] =
+                0.5F * (1.0F - cosf(2.0F * PI * (float)n / (floatN - 1)));
+        }
+
+        return window;
+    }
+
+    static std::vector<float>
+    init_const_normalized_window(const std::vector<float> &window,
+                                 int nb_frames)
+    {
+        float window_normalization_factor =
+            FFT_WINDOW_SIZE + FFT_HOP_SIZE * (nb_frames - 1);
+        std::vector<float> normalized_window =
+            std::vector<float>(window_normalization_factor, 0.0f);
+
+        // Compute the window normalization factor
+        // using librosa window_sumsquare to compute the squared window
+        // https://github.com/librosa/librosa/blob/main/librosa/filters.py#L1545
+        for (int i = 0; i < nb_frames; ++i)
+        {
+            auto sample = i * FFT_HOP_SIZE;
+            for (int j = sample; j < std::min((int)window_normalization_factor,
+                                              sample + FFT_WINDOW_SIZE);
+                 ++j)
+            {
+                normalized_window[j] += window[j - sample] * window[j - sample];
+            }
+        }
+        return normalized_window;
+    }
+};
+
+void stft(
+    struct stft_buffers &stft_buf,
+    const Eigen::MatrixXf &waveform,
+    Eigen::Tensor3dXcf &spec);
+
+void istft(
+    struct stft_buffers &stft_buf,
+    const Eigen::Tensor3dXcf &spec,
+    Eigen::MatrixXf &waveform);
+
+} // namespace demucsonnx
+
+#endif // DSP_HPP

--- a/cppscripts/src/model_apply.cpp
+++ b/cppscripts/src/model_apply.cpp
@@ -1,0 +1,214 @@
+#include "demucs.hpp"
+#include "dsp.hpp"
+#include <Eigen/Dense>
+#include <cmath>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <random>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <unsupported/Eigen/FFT>
+#include <unsupported/Eigen/MatrixFunctions>
+#include <vector>
+#include <Eigen/Dense>
+#include <onnxruntime/onnxruntime_cxx_api.h>
+#include <unsupported/Eigen/CXX11/Tensor>
+#include "demucs.hpp"
+
+// At global/class scope
+static std::random_device rd;  // Get entropy for seed
+static std::mt19937 gen(rd()); // Mersenne Twister generator
+
+static void reflect_padding(
+    Eigen::MatrixXf &padded_mix,
+    int left_padding,
+    int right_padding,
+    int N)
+{
+    // Reflect from the first 'left_padding' samples of the original data
+    for (int i = 0; i < left_padding; ++i)
+    {
+        padded_mix.block(0, left_padding - 1 - i, 2, 1) =
+            padded_mix.block(0, left_padding + i, 2, 1);
+    }
+
+    // Reflect from the last 'right_padding' samples of the original data
+    for (int i = 0; i < right_padding; ++i)
+    {
+        int last_elem = N + left_padding - 1 ;
+        padded_mix.block(0, last_elem + i + 1, 2, 1) =
+            padded_mix.block(0, last_elem - i, 2, 1);
+    }
+}
+
+Eigen::Tensor3dXf demucsonnx::demucs_inference(
+    struct demucsonnx::demucs_model &model,
+    const Eigen::MatrixXf &audio,
+    demucsonnx::ProgressCallback cb)
+{
+    int length = audio.cols();
+    int max_shift = static_cast<int>(demucsonnx::MAX_SHIFT_SECS * demucsonnx::SUPPORTED_SAMPLE_RATE);
+
+    // Calculate the overall mean and standard deviation
+    Eigen::VectorXf ref_mean_0 = audio.colwise().mean();
+    float ref_mean = ref_mean_0.mean();
+    float ref_std = std::sqrt((ref_mean_0.array() - ref_mean).square().sum() /
+                              (ref_mean_0.size() - 1));
+
+    // Create padded_mix with symmetric zero padding
+    int padded_length = length + 2 * max_shift;
+    Eigen::MatrixXf padded_mix(2, padded_length);
+    padded_mix.setZero();
+
+    // Normalize and copy audio into padded_mix starting at column max_shift
+    padded_mix.block(0, max_shift, 2, length) = (audio.array() - ref_mean) / ref_std;
+
+    // Generate random shift offset for time invariance
+    std::uniform_int_distribution<> dist(0, max_shift - 1);
+    int shift_offset = dist(gen);
+    std::cout << "shift offset is: " << shift_offset << std::endl;
+
+    // Create a block view for shifted_audio to avoid extra allocation
+    int shifted_length = length + max_shift - shift_offset;
+    Eigen::Ref<const Eigen::MatrixXf> shifted_audio = padded_mix.block(0, shift_offset, 2, shifted_length);
+
+    // --- Begin merged split_inference and segment_inference logic ---
+
+    // Calculate segment size in samples
+    int segment_samples = static_cast<int>(demucsonnx::SEGMENT_LEN_SECS * demucsonnx::SUPPORTED_SAMPLE_RATE);
+    int nb_out_sources = model.nb_sources;
+
+    // Create reusable buffers with padded sizes
+    demucsonnx::demucs_segment_buffers buffers(2, segment_samples, nb_out_sources);
+
+    // Calculate stride for overlapping segments
+    int stride_samples = static_cast<int>((1.0f - demucsonnx::OVERLAP) * segment_samples);
+
+    // Create an output tensor initialized to zero
+    Eigen::Tensor3dXf out(nb_out_sources, 2, shifted_length);
+    out.setZero();
+
+    // Create weight vector for overlapping segments
+    Eigen::VectorXf weight(segment_samples);
+    int half_segment = segment_samples / 2;
+    weight.head(half_segment) = Eigen::VectorXf::LinSpaced(half_segment, 1, half_segment);
+    weight.tail(half_segment) = weight.head(half_segment).reverse();
+    weight /= weight.maxCoeff();
+    weight = weight.array().pow(demucsonnx::TRANSITION_POWER);
+
+    // Initialize sum_weight as Eigen::VectorXf
+    Eigen::VectorXf sum_weight(shifted_length);
+    sum_weight.setZero();
+
+    // Calculate total number of chunks
+    int total_chunks = static_cast<int>(std::ceil(static_cast<float>(shifted_length) / stride_samples));
+    float increment_per_chunk = 1.0f / static_cast<float>(total_chunks);
+    float inference_progress = 0.0f;
+
+    // Preallocate a tensor for chunk_out to avoid repeated allocations
+    Eigen::Tensor3dXf chunk_out(nb_out_sources, 2, segment_samples);
+    chunk_out.setZero();
+
+    // Process each segment
+    for (int segment_offset = 0; segment_offset < shifted_length; segment_offset += stride_samples)
+    {
+        int chunk_length = std::min(segment_samples, shifted_length - segment_offset);
+
+        // Create a block view for the current chunk
+        Eigen::Ref<const Eigen::MatrixXf> chunk = shifted_audio.block(0, segment_offset, 2, chunk_length);
+
+        // first, symmetric padding with zeros to fit the smaller chunk
+        // into the bigger segment_samples
+        int symmetric_padding = buffers.padded_segment_samples - chunk_length;
+
+        buffers.padded_mix.setZero();
+        // copy chunk into padded_mix at position buffers.pad + symmetric_padding/2
+        int symmetric_padding_start = symmetric_padding / 2;
+        buffers.padded_mix.block(0, buffers.pad + symmetric_padding_start, 2, chunk_length) = chunk;
+
+        // then, reflect padding on the left and right for
+        // the stft boundary effects
+        reflect_padding(buffers.padded_mix, buffers.pad, buffers.pad_end, segment_samples);
+
+        // Run model inference
+        demucsonnx::model_inference(model, buffers);
+
+        // Update progress
+        cb(inference_progress + increment_per_chunk, "Segment inference complete");
+
+        // Copy from buffers.targets_out into chunk_out with center trimming
+        // Preallocate chunk_out and set to zero
+        chunk_out.setZero();
+
+        for (int i = 0; i < nb_out_sources; ++i)
+        {
+            for (int j = 0; j < 2; ++j)
+            {
+                for (int k = 0; k < chunk_length; ++k)
+                {
+                    auto kidx = k + symmetric_padding_start;
+                    kidx = std::min(kidx, int(buffers.targets_out.dimension(2)-1));
+                    // Undoing center_trim by offsetting with left_padding
+                    chunk_out(i, j, k) = buffers.targets_out(i, j, kidx);
+                }
+            }
+        }
+
+        // Accumulate the weighted chunk output using Eigen::Map for vectorization
+        for (int i = 0; i < nb_out_sources; ++i)
+        {
+            for (int j = 0; j < 2; ++j)
+            {
+                // Map the (i, j, chunk_length) slice of 'out' to an Eigen::ArrayXf
+                Eigen::Map<Eigen::ArrayXf> out_slice(&out(i, j, segment_offset), chunk_length);
+                // Map the (i, j, chunk_length) slice of 'chunk_out' to an Eigen::ArrayXf
+                Eigen::Map<const Eigen::ArrayXf> chunk_out_slice(&chunk_out(i, j, 0), chunk_length);
+                // Accumulate the weighted chunk output
+                out_slice += weight.head(chunk_length).array() * chunk_out_slice;
+            }
+        }
+
+        // Accumulate the weights using Eigen's segment operation
+        sum_weight.segment(segment_offset, chunk_length) += weight.head(chunk_length);
+
+        inference_progress += increment_per_chunk;
+    }
+
+    // Normalize the output by sum_weight using vectorized operations
+    for (int i = 0; i < nb_out_sources; ++i)
+    {
+        for (int j = 0; j < 2; ++j)
+        {
+            // Map the (i, j, shifted_length) slice of 'out' to an Eigen::ArrayXf
+            Eigen::Map<Eigen::ArrayXf> out_slice(&out(i, j, 0), shifted_length);
+            // Perform element-wise division
+            out_slice /= sum_weight.array();
+        }
+    }
+
+    // Inverse the normalization directly on 'out' using vectorized operations
+    for (int i = 0; i < nb_out_sources; ++i)
+    {
+        for (int j = 0; j < 2; ++j)
+        {
+            // Map the (i, j, shifted_length) slice of 'out' to an Eigen::ArrayXf
+            Eigen::Map<Eigen::ArrayXf> out_slice(&out(i, j, 0), shifted_length);
+            // Perform inverse normalization
+            out_slice = out_slice * ref_std + ref_mean;
+        }
+    }
+
+    // Create a view (slice) of 'out' without allocating new memory
+    int trim_start = max_shift - shift_offset;
+    Eigen::array<Eigen::Index, 3> offset_array = {0, 0, trim_start};
+    Eigen::array<Eigen::Index, 3> extent_array = {nb_out_sources, 2, length};
+    auto result = out.slice(offset_array, extent_array);
+
+    // Materialize the slice into a new tensor to return
+    Eigen::Tensor3dXf trimmed_waveform_outputs = result.eval();
+
+    return trimmed_waveform_outputs;
+}

--- a/cppscripts/src/model_inference.cpp
+++ b/cppscripts/src/model_inference.cpp
@@ -1,0 +1,135 @@
+#include "demucs.hpp"
+#include "dsp.hpp"
+#include <Eigen/Dense>
+#include <cmath>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <random>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <unsupported/Eigen/FFT>
+#include <unsupported/Eigen/MatrixFunctions>
+#include <vector>
+#include <Eigen/Dense>
+#include <onnxruntime/onnxruntime_cxx_api.h>
+#include <unsupported/Eigen/CXX11/Tensor>
+#include "demucs.hpp"
+
+namespace demucsonnx {
+    Ort::AllocatorWithDefaultOptions allocator;
+    Ort::RunOptions run_options;
+}
+
+// Core function to create and load model from in-memory data (byte array)
+bool demucsonnx::load_model(
+    const char* model_data,
+    int n_bytes,
+    struct demucsonnx::demucs_model &model,
+    Ort::SessionOptions &session_options)
+{
+    const uint8_t* final_data = reinterpret_cast<const uint8_t*>(model_data);
+    size_t final_size = n_bytes;
+
+    model.sess = std::make_unique<Ort::Session>(model.env, final_data, final_size, session_options);
+
+    std::vector<Ort::AllocatedStringPtr> input_name_allocs;
+    input_name_allocs.push_back(model.sess->GetInputNameAllocated(0, demucsonnx::allocator));
+
+    model.input_names.push_back(input_name_allocs[0].get());  // Store as std::string
+
+    std::vector<Ort::AllocatedStringPtr> output_name_allocs;
+    output_name_allocs.push_back(model.sess->GetOutputNameAllocated(0, demucsonnx::allocator));
+
+    model.output_names.push_back(output_name_allocs[0].get());
+
+    for (const auto& name : model.input_names) {
+        model.input_names_ptrs.push_back(name.c_str());
+    }
+    for (const auto& name : model.output_names) {
+        model.output_names_ptrs.push_back(name.c_str());
+    }
+
+    auto output0_shape = model.sess->GetOutputTypeInfo(0).GetTensorTypeAndShapeInfo().GetShape();
+
+    model.nb_sources = output0_shape[1];
+    return true;
+}
+
+// Overload for std::vector<char>
+bool demucsonnx::load_model(
+    const std::vector<char> &model_data,
+    struct demucsonnx::demucs_model &model,
+    Ort::SessionOptions &session_options)
+{
+    return load_model(
+        model_data.data(), model_data.size(), model, session_options);
+}
+
+void RunONNXInference(
+    struct demucsonnx::demucs_model &model,
+    struct demucsonnx::demucs_segment_buffers &buffers
+) {
+    // Run the model
+    model.sess->Run(
+        demucsonnx::run_options,
+        model.input_names_ptrs.data(),
+        buffers.input_tensors.data(),
+        buffers.input_tensors.size(),
+        model.output_names_ptrs.data(),
+        buffers.output_tensors.data(),
+        model.output_names_ptrs.size()
+    );
+}
+
+// run core demucs inference using onnx
+void demucsonnx::model_inference(
+    struct demucsonnx::demucs_model &model,
+    struct demucsonnx::demucs_segment_buffers &buffers)
+    // struct demucsonnx::stft_buffers &stft_buf)
+{
+
+    // prepare time branch input by copying buffers.mix into  input_tensors[0]
+    float *xt_onnx_data = buffers.input_tensors[0].GetTensorMutableData<float>();
+
+    for (int i = 0; i < buffers.padded_mix.rows(); ++i)
+    {
+        for (int j = 0; j < buffers.segment_samples; ++j)
+        {
+            // calculate destination index, simple row major calculation
+            // given the onnx shape of (1, 2, segment_samples)
+            int dest_index = i * buffers.segment_samples + j;
+            xt_onnx_data[dest_index] = buffers.padded_mix(i, j + buffers.pad);
+        }
+    }
+    
+    // now we apply the core demucs inference
+    RunONNXInference(model, buffers);
+
+    std::cout << "ONNX inference completed." << std::endl;
+
+    int nb_out_sources = model.nb_sources;
+
+    // nb_sources sources, 2 channels, N samples
+    std::vector<Eigen::MatrixXf> xt_3d(
+        nb_out_sources,
+        Eigen::MatrixXf(2, buffers.segment_samples)
+    );
+
+    // Map output onnx tensors
+    float* xt_out_data = buffers.output_tensors[0].GetTensorMutableData<float>();
+
+    for (int s = 0; s < nb_out_sources; ++s)
+    { // loop over 4 sources
+        for (int i = 0; i < 2; ++i)
+        {
+            for (int j = 0; j < buffers.segment_samples; ++j)
+            {
+                int index = s * 2 * buffers.segment_samples + i * buffers.segment_samples + j;
+                buffers.targets_out(s, i, j) = xt_out_data[index];
+            }
+        }
+    }
+}

--- a/cppscripts/src/tensor.hpp
+++ b/cppscripts/src/tensor.hpp
@@ -1,0 +1,24 @@
+#ifndef TENSOR_HPP
+#define TENSOR_HPP
+
+#include <Eigen/Dense>
+#include <complex>
+#include <iostream>
+#include <string>
+#include <unsupported/Eigen/CXX11/Tensor>
+#include <vector>
+#include <limits>
+#include <onnxruntime/onnxruntime_cxx_api.h>
+
+namespace Eigen
+{
+// define Tensor3dXf, Tensor3dXcf for spectrograms etc.
+typedef Tensor<float, 5, RowMajor> Tensor5dXf;
+typedef Tensor<float, 4, RowMajor> Tensor4dXf;
+typedef Tensor<float, 3, RowMajor> Tensor3dXf;
+typedef Tensor<float, 2, RowMajor> Tensor2dXf;
+typedef Tensor<float, 1, RowMajor> Tensor1dXf;
+typedef Tensor<std::complex<float>, 3, RowMajor> Tensor3dXcf;
+} // namespace Eigen
+
+#endif // TENSOR_HPP

--- a/cppscripts/src_cli/CMakeLists.txt
+++ b/cppscripts/src_cli/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.0)
+
+project(demucs.onnx)
+enable_testing()
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+set(CMAKE_CXX_FLAGS "-Wall -Wextra")
+set(CMAKE_CXX_FLAGS_DEBUG "-g -DEIGEN_INTERNAL_DEBUGGING")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -march=native -ffast-math -flto -fno-signed-zeros -fassociative-math -freciprocal-math -fno-math-errno -fno-rounding-math -funsafe-math-optimizations -fno-trapping-math -fno-rtti -DNDEBUG")
+
+# Set your onnxruntime installation path here
+set(ONNXRUNTIME_HOME /opt/homebrew/Cellar/onnxruntime/1.21.0)
+include_directories(${ONNXRUNTIME_HOME}/include)
+link_directories(${ONNXRUNTIME_HOME}/lib)
+
+set(LIBNYQUIST_BUILD_EXAMPLE OFF CACHE BOOL "Disable libnyquist example")
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../dependencies/libnyquist ${CMAKE_CURRENT_BINARY_DIR}/libnyquist_build)
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../src)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../dependencies/eigen)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../dependencies/libnyquist/include)
+
+file(GLOB SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../src/*.cpp" "${CMAKE_CURRENT_SOURCE_DIR}/../src_cli/*.cpp" "${CMAKE_CURRENT_SOURCE_DIR}/../onnx-models/model/*.ort.c")
+add_executable(demucs ${SOURCES})
+
+target_link_libraries(demucs onnxruntime libnyquist)

--- a/cppscripts/src_cli/demucs.cpp
+++ b/cppscripts/src_cli/demucs.cpp
@@ -1,0 +1,289 @@
+#include "demucs.hpp"
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <libnyquist/Common.h>
+#include <libnyquist/Decoders.h>
+#include <libnyquist/Encoders.h>
+#include <map>
+#include <numeric>
+#include <ranges>
+#include <sstream>
+#include <stddef.h>
+#include <tuple>
+#include <vector>
+
+using namespace nqr;
+
+// Overload for file path, calling one of the other overloads as needed
+static demucsonnx::demucs_model load_model(
+    const std::string& htdemucs_model_path,
+    Ort::SessionOptions& session_options
+) {
+    struct demucsonnx::demucs_model model;
+
+    std::ifstream file(htdemucs_model_path, std::ios::binary | std::ios::ate);
+    if (!file) {
+        throw std::runtime_error("Failed to open model file: " + htdemucs_model_path);
+    }
+
+    std::streamsize size = file.tellg();
+    file.seekg(0, std::ios::beg);
+
+    std::vector<char> file_data(size);
+    if (!file.read(file_data.data(), size)) {
+        throw std::runtime_error("Failed to read model file.");
+    }
+
+    bool success = demucsonnx::load_model(file_data, model, session_options);
+    if (!success) {
+        throw std::runtime_error("Failed to load model.");
+    }
+
+    return model;
+}
+
+static Eigen::MatrixXf load_audio_file(std::string filename)
+{
+    // load a wav file with libnyquist
+    std::shared_ptr<AudioData> fileData = std::make_shared<AudioData>();
+
+    NyquistIO loader;
+
+    loader.Load(fileData.get(), filename);
+
+    if (fileData->sampleRate != demucsonnx::SUPPORTED_SAMPLE_RATE)
+    {
+        std::cerr << "[ERROR] demucs.cpp only supports the following sample "
+                     "rate (Hz): "
+                  << demucsonnx::SUPPORTED_SAMPLE_RATE << std::endl;
+        exit(1);
+    }
+
+    std::cout << "Input samples: "
+              << fileData->samples.size() / fileData->channelCount << std::endl;
+    std::cout << "Length in seconds: " << fileData->lengthSeconds << std::endl;
+    std::cout << "Number of channels: " << fileData->channelCount << std::endl;
+
+    if (fileData->channelCount != 2 && fileData->channelCount != 1)
+    {
+        std::cerr << "[ERROR] demucs.cpp only supports mono and stereo audio"
+                  << std::endl;
+        exit(1);
+    }
+
+    // number of samples per channel
+    std::size_t N = fileData->samples.size() / fileData->channelCount;
+
+    // create a struct to hold two float vectors for left and right channels
+    Eigen::MatrixXf ret(2, N);
+
+    if (fileData->channelCount == 1)
+    {
+        // Mono case
+        for (std::size_t i = 0; i < N; ++i)
+        {
+            ret(0, i) = fileData->samples[i]; // left channel
+            ret(1, i) = fileData->samples[i]; // right channel
+        }
+    }
+    else
+    {
+        // Stereo case
+        for (std::size_t i = 0; i < N; ++i)
+        {
+            ret(0, i) = fileData->samples[2 * i];     // left channel
+            ret(1, i) = fileData->samples[2 * i + 1]; // right channel
+        }
+    }
+
+    return ret;
+}
+
+// write a function to write a StereoWaveform to a wav file
+static void write_audio_file(const Eigen::MatrixXf &waveform,
+                             std::string filename)
+{
+    // create a struct to hold the audio data
+    std::shared_ptr<AudioData> fileData = std::make_shared<AudioData>();
+
+    // set the sample rate
+    fileData->sampleRate = demucsonnx::SUPPORTED_SAMPLE_RATE;
+
+    // set the number of channels
+    fileData->channelCount = 2;
+
+    // set the number of samples
+    fileData->samples.resize(waveform.cols() * 2);
+
+    // write the left channel
+    for (long int i = 0; i < waveform.cols(); ++i)
+    {
+        fileData->samples[2 * i] = waveform(0, i);
+        fileData->samples[2 * i + 1] = waveform(1, i);
+    }
+
+    int encoderStatus =
+        encode_wav_to_disk({fileData->channelCount, PCM_FLT, DITHER_TRIANGLE},
+                           fileData.get(), filename);
+    std::cout << "Encoder Status: " << encoderStatus << std::endl;
+}
+
+int main(int argc, const char **argv)
+{
+
+    try {
+        // your existing main logic
+
+        if (argc != 4)
+        {
+            std::cerr << "Usage: " << argv[0] << " <model file> <wav file> <out dir>"
+                      << std::endl;
+            exit(1);
+        }
+    
+        std::cout << "demucs.onnx Main driver program" << std::endl;
+        std::string model_file = argv[1];
+    
+        // load audio passed as argument
+        std::string wav_file = argv[2];
+    
+        // output dir passed as argument
+        std::string out_dir = argv[3];
+    
+        // Check if the output directory exists, and create it if not
+        std::filesystem::path output_dir_path(out_dir);
+        if (!std::filesystem::exists(output_dir_path))
+        {
+            std::cerr << "Directory does not exist: " << out_dir << ". Creating it."
+                      << std::endl;
+            if (!std::filesystem::create_directories(output_dir_path))
+            {
+                std::cerr << "Error: Unable to create directory: " << out_dir
+                          << std::endl;
+                return 1;
+            }
+        }
+        else if (!std::filesystem::is_directory(output_dir_path))
+        {
+            std::cerr << "Error: " << out_dir << " exists but is not a directory!"
+                      << std::endl;
+            return 1;
+        }
+    
+        Eigen::MatrixXf audio = load_audio_file(wav_file);
+        Eigen::Tensor3dXf out_targets;
+    
+        std::cout << "Running Demucs.onnx inference for: " << wav_file << std::endl;
+    
+            // set output precision to 3 decimal places
+        std::cout << std::fixed << std::setprecision(3);
+    
+        demucsonnx::ProgressCallback progressCallback =
+            [](float progress, const std::string &log_message)
+        {
+            std::cout << "(" << std::setw(3) << std::setfill(' ')
+                      << progress * 100.0f << "%) " << log_message << std::endl;
+        };
+    
+        // create Ort::SessionOptions
+        Ort::SessionOptions session_options;
+    
+        // max out threads and increase performance to the max on my beefy
+        // desktop CPU
+        session_options.SetExecutionMode(ExecutionMode::ORT_PARALLEL);
+        session_options.SetIntraOpNumThreads(16);
+        session_options.SetInterOpNumThreads(16);
+    
+        // General optimizations
+        session_options.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_ALL);
+    
+        struct demucsonnx::demucs_model model = load_model(
+            model_file,
+            session_options
+        );
+    
+        // create 4 audio matrix same size, to hold output
+        Eigen::Tensor3dXf audio_targets =
+            demucsonnx::demucs_inference(model, audio, progressCallback);
+    
+        out_targets = audio_targets;
+    
+        int nb_out_sources = model.nb_sources;
+    
+        for (int target = 0; target < nb_out_sources; ++target)
+        {
+            // now write the 4 audio waveforms to files in the output dir
+            // using libnyquist
+            // join out_dir with "/target_0.wav"
+            // using std::filesystem::path;
+    
+            std::filesystem::path p = out_dir;
+            // make sure the directory exists
+            std::filesystem::create_directories(p);
+    
+            auto p_target = p / "target_0.wav";
+    
+            // target 0,1,2,3 map to drums,bass,other,vocals
+    
+            std::string target_name;
+    
+            switch (target)
+            {
+            case 0:
+                target_name = "drums";
+                break;
+            case 1:
+                target_name = "bass";
+                break;
+            case 2:
+                target_name = "other";
+                break;
+            case 3:
+                target_name = "vocals";
+                break;
+            case 4:
+                target_name = "guitar";
+                break;
+            case 5:
+                target_name = "piano";
+                break;
+            default:
+                std::cerr << "Error: target " << target << " not supported"
+                          << std::endl;
+                exit(1);
+            }
+    
+            // insert target_name into the path after the digit
+            // e.g. target_name_0_drums.wav
+            p_target.replace_filename("target_" + std::to_string(target) + "_" +
+                                      target_name + ".wav");
+    
+            std::cout << "Writing wav file " << p_target << std::endl;
+    
+            Eigen::MatrixXf target_waveform(2, audio.cols());
+    
+            // copy the input stereo wav file into all 4 targets
+            for (int channel = 0; channel < 2; ++channel)
+            {
+                for (int sample = 0; sample < audio.cols(); ++sample)
+                {
+                    target_waveform(channel, sample) =
+                        out_targets(target, channel, sample);
+                }
+            }
+    
+            write_audio_file(target_waveform, p_target);
+        }
+    
+        return 0;
+    } catch (const std::exception& e) {
+        std::cerr << "Caught exception: " << e.what() << std::endl;
+        return 1;
+    }
+
+}

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,0 +1,127 @@
+# Demucs Benchmarking Guide
+
+This guide explains how to run performance benchmarks for Demucs music source separation using both PyTorch and C++ ONNX implementations.
+
+## Overview
+
+The benchmarking system provides comprehensive evaluation including:
+
+- **Separation timing** - How long inference takes
+- **SI-SDR evaluation** - Audio quality metrics (Scale-Invariant Signal-to-Distortion Ratio)
+- **JSON results output** - Structured data for further analysis
+- **Resume capability** - Skip already processed tracks
+
+Both benchmark scripts use a shared `benchmark_common.py` module to ensure consistent evaluation methodology.
+
+## Prerequisites
+
+### Dataset Requirements
+
+- **MusDB-HQ dataset** - Download from [https://sigsep.github.io/datasets/musdb.html](https://sigsep.github.io/datasets/musdb.html)
+- Expected directory structure:
+  ```
+  musdb-root/
+  ├── test/
+  │   ├── track1/
+  │   │   ├── mixture.wav
+  │   │   ├── drums.wav
+  │   │   ├── bass.wav
+  │   │   ├── other.wav
+  │   │   └── vocals.wav
+  │   ├── track2/
+  │   └── ...
+  └── train/ (optional)
+  ```
+
+### Python Dependencies
+
+```bash
+pip install torch torchaudio torchmetrics numpy
+```
+
+## PyTorch Benchmark
+
+The PyTorch benchmark uses the original Demucs PyTorch implementation for inference.
+
+### Basic Usage
+
+```bash
+cd benchmark
+python benchmark-pytorch.py --musdb-root /path/to/musdb-hq/
+```
+
+### Arguments
+
+- `--musdb-root` (required): Path to MusDB dataset root directory
+- `--output-root` (optional): Where to store separated outputs (default: inside musdb-root)
+- `--output-dir` (optional): Output directory name (default: `test-separated-pytorch`)
+- `--json-out` (optional): JSON file for benchmark results (default: `benchmark_results_pytorch.json`)
+- `--force-reseparate` (optional): Force re-separation even if files already exist
+
+## C++ ONNX Benchmark
+
+The C++ ONNX benchmark uses a C++ CLI tool with ONNX runtime for inference.
+
+### Prerequisites
+
+- **C++ CLI tool built** - The C++ CLI build path.
+- **ONNX model file** - The exported ONNX model path.
+
+### Basic Usage
+
+```bash
+cd benchmark
+python benchmark-cpp-onnx.py --musdb-root /path/to/musdb-hq/
+```
+
+### Arguments
+
+- `--musdb-root` (required): Path to MusDB dataset root directory
+- `--output-root` (optional): Where to store separated outputs (default: inside musdb-root)
+- `--output-dir` (optional): Output directory name (default: `test-separated-cpp`)
+- `--json-out` (optional): JSON file for benchmark results (default: `benchmark_results_cpp.json`)
+- `--cli-path` (optional): Path to C++ ONNX CLI executable (default: `../cppscripts/build/build-cli/demucs`)
+- `--model-path` (optional): Path to ONNX model file (default: `../onnx-models/htdemucs.ort`)
+- `--force-reseparate` (optional): Force re-separation even if files already exist
+
+## Output Files
+
+### Separated Audio
+
+Both benchmarks create the same output structure:
+```
+output-directory/
+├── track1/
+│   ├── target_0_drums.wav
+│   ├── target_1_bass.wav
+│   ├── target_2_other.wav
+│   └── target_3_vocals.wav
+├── track2/
+└── ...
+```
+
+### JSON Results
+
+Benchmark results are saved as JSON files with detailed statistics:
+
+```json
+{
+  "summary": {
+    "model_identifier": "htdemucs",
+    "total_tracks": 50,
+    "total_proc_sec": 0.0,
+    "total_wall_time_sec": 0.011753082275390625,
+    "total_audio_sec": 12470.980884353747,
+    "avg_time_per_min": 0.0,
+    "sisdr_mean_per_stem": {
+      "drums": 9.457932338714599,
+      "bass": 7.763716798424721,
+      "other": 4.687467608451843,
+      "vocals": 7.8351172041893005
+    },
+    "overall_sisdr_mean": 7.436058487445116
+  },
+  "per_track_stats": [...],
+  "per_track_sisdr": [...]
+}
+```

--- a/docs/onnx.md
+++ b/docs/onnx.md
@@ -2,14 +2,39 @@
 
 ## Convert PyTorch model to ONNX and ORT
 
-Convert Demucs PyTorch model to ONNX:
+- Convert Demucs PyTorch model to ONNX:
 
 ```python
 python ./scripts/convert-pth-to-onnx.py ./onnx-models
 ```
 
-Optionally, convert ONNX model to ORT:
+- Optionally, convert ONNX model to ORT:
 
 ```python
 python -m onnxruntime.tools.convert_onnx_models_to_ort ./onnx-models --enable_type_reduction 
+```
+
+## Using C++ scripts
+
+- Install dependencies
+
+```git
+git submodule update --init --recursive
+```
+
+- Set ONNXRuntime path in `./cppscripts/src_cli/CMakeLists.txt`
+
+- Compile the C++ code
+
+```bash
+cd cppscripts
+make cli
+cd ..
+```
+
+- Run inference using the following command
+
+```bash
+mkdir ./separated/htdemucs_cpp/
+./cppscripts/build/build-cli/demucs ./onnx-models/htdemucs.ort ./test.mp3 ./separated/htdemucs_cpp/
 ```


### PR DESCRIPTION
Add benchmarking for PyTorch Demucs and C++ ONNX scripts -
 - Separation quality using SI-SDR
 - Performance metrics on CPU
 - Performance metrics on GPU

## CPU Performance Comparison

### Processing Speed

| Metric | PyTorch Model | C++ ONNX Model | Improvement |
|--------|---------------|----------------|-------------|
| Total Processing Time | 5,380.35 sec | 4,415.30 sec | **17.94% faster** |
| Processing Time for 1 min input | 25.89 sec | 21.24 sec | **17.94% faster** |

### Audio Quality (SI-SDR in dB)

| Stem | PyTorch Model (dB) | C++ ONNX Model (dB) | Difference |
|------|-------------------|---------------------|------------|
| drums | 9.50 | 9.48 | -0.02 |
| bass | 7.87 | 7.80 | -0.07 |
| other | 4.75 | 4.66 | -0.09 |
| vocals | 7.90 | 7.82 | -0.08 |
| **Overall** | **7.50** | **7.44** | **-0.06** |

### Summary Statistics

| Dataset | PyTorch Model | C++ ONNX Model |
|---------|---------------|----------------|
| Total Tracks | 50 | 50 |
| Total Audio Duration | 12,470.98 sec (~3.46 hours) | 12,470.98 sec (~3.46 hours) |
| Model Identifier | htdemucs | ../onnx-models/htdemucs.ort |

## Key Findings

- **Performance**: The C++ ONNX model is **17.94% faster** than the PyTorch implementation
- **Quality**: Audio separation quality is nearly identical, with only minor differences (< 0.1 dB) in SI-SDR scores
- **Consistency**: Both models processed the same 50 tracks from the dataset with no failures

The results demonstrate that the ONNX export successfully maintains the audio quality while providing performance improvements for deployment scenarios.

## GPU Performance Comparison

Unlike the CPU comparison which uses C++, this ONNX inference was done on Python using ONNXRuntime.

### Processing Speed

| Metric | PyTorch Model (GPU) | Python ONNXRuntime (GPU) | Difference |
|--------|---------------------|------------------|------------|
| Total Processing Time | 354.13 sec | 386.40 sec | **8.35% slower** |
| Processing Time for 1 min input | 1.70 sec | 1.86 sec | **8.35% slower** |

### Audio Quality (SI-SDR in dB)

| Stem | PyTorch Model (dB) | Python ONNXRuntime (dB) | Difference |
|------|-------------------|------------------|------------|
| drums | 9.49 | 9.50 | +0.01 |
| bass | 7.77 | 7.88 | +0.11 |
| other | 4.72 | 4.76 | +0.04 |
| vocals | 7.85 | 7.87 | +0.02 |
| **Overall** | **7.46** | **7.50** | **+0.04** |

### Summary Statistics

| Dataset | PyTorch Model (GPU) | Python ONNXRuntime (GPU) |
|---------|---------------------|------------------|
| Total Tracks | 50 | 50 |
| Total Audio Duration | 12,470.98 sec (~3.46 hours) | 12,470.98 sec (~3.46 hours) |
| Model Identifier | htdemucs | htdemucs |

## Key Findings

- **Performance**: The PyTorch model is **8.35% faster** than the ONNX model run on Python.
- **Quality**: Audio separation quality is very similar, with the ONNX model showing slightly better SI-SDR scores (+0.04 dB overall)
- **Consistency**: Both models processed the same 50 tracks from the dataset with no failures

The results show that on GPU, PyTorch maintains a performance advantage while both models deliver comparable audio quality.
 